### PR TITLE
Extract kernel version from generated deb package

### DIFF
--- a/rootfs/scripts/build-ubuntu-rootfs.sh
+++ b/rootfs/scripts/build-ubuntu-rootfs.sh
@@ -395,7 +395,7 @@ echo '[CHROOT] Installing manifest packages (if any)...'
 /install_manifest_pkgs.sh || true
 
 echo '[CHROOT] Detecting installed kernel version...'
-kernel_ver=\$(ls /boot/vmlinuz-* | sed 's|.*/vmlinuz-||' | sort -V | tail -n1)
+kernel_ver=\$(echo "$KERNEL_DEB" | sed -n 's/linux-kernel-\(.*\)-arm64\.deb/\1/p')
 crd_dtb_path=\"/lib/firmware/\$kernel_ver/device-tree/x1e80100-crd.dtb\"
 
 echo '[CHROOT] Writing GRUB configuration...'


### PR DESCRIPTION
Currently kernel version is being extracted from the avaliable files present in the rootfs.

vmlinuz-6.17.0-00001-g7b3ecb1fbc38
vmlinuz-6.17.0-5-generic

kernel_ver=\$(ls /boot/vmlinuz-* | sed 's|.*/vmlinuz-||' | sort -V | tail -n1)

With 6.17 kernel version being generated is kernel-6.17.0-00001-g7b3ecb1fbc38, and the above condition is failing and returning the generic kernel version 6.17.0-5-generic

To fix this use the kernel version from the kernel debian package that is generated from the build.