### PR TITLE
Fix : Extract kernel version from debian package

### DIFF
--- a/rootfs/scripts/build-ubuntu-rootfs.sh
+++ b/rootfs/scripts/build-ubuntu-rootfs.sh
@@ -395,7 +395,7 @@ echo '[CHROOT] Installing manifest packages (if any)...'
 /install_manifest_pkgs.sh || true
 
 echo '[CHROOT] Detecting installed kernel version...'
-kernel_ver=\$(echo "$KERNEL_DEB" | sed -n 's/linux-kernel-\(.*\)-arm64\.deb/\1/p')
+kernel_ver=\$(echo "$KERNEL_DEB" | sed -n 's|.*/linux-kernel-\(.*\)-arm64\.deb|\1|p')
 crd_dtb_path=\"/lib/firmware/\$kernel_ver/device-tree/x1e80100-crd.dtb\"
 
 echo '[CHROOT] Writing GRUB configuration...'


### PR DESCRIPTION
Debian package name that is being passed to build-ubuntu-rootfs.sh script, also contains path as kernel/.

This is not handled in the current implementation.

Fix the regex to ignore any string before the kernel version.