### PR TITLE
Switch default build runner to arm64

### DIFF
--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -46,7 +46,7 @@ on:
       runner:
         description: The runner to use for the build
         type: string
-        default: ubuntu-latest
+        default: lecore-prd-u2404-arm64-xlrg-od-ephem
 
     secrets:
       TOKEN:


### PR DESCRIPTION
make the default runner for builds be the arm64 ephemeral aws runners