### PR TITLE
Strip CI run_id suffix from kernel_ver derivation

### DIFF
--- a/rootfs/scripts/build-ubuntu-rootfs.sh
+++ b/rootfs/scripts/build-ubuntu-rootfs.sh
@@ -497,7 +497,11 @@ echo '[CHROOT] Base package list preserved as /tmp/\${CODENAME}_base.manifest'
 echo '[CHROOT] Custom installed packages saved to /tmp/packages_\${DATE}.manifest'
 
 echo '[CHROOT] Detecting installed kernel version...'
-kernel_ver=\$(echo "$KERNEL_DEB" | sed -n 's|.*/linux-kernel-\(.*\)-arm64\.deb|\1|p')
+
+kernel_ver=$(basename "$KERNEL_DEB" \
+  | sed 's|^linux-kernel-\(.*\)-arm64\.deb$|\1|' \
+  | sed 's|-[0-9][0-9]*-[0-9][0-9]*$||')
+
 crd_dtb_path=\"/lib/firmware/\$kernel_ver/device-tree/x1e80100-crd.dtb\"
 evk_dtb_path=\"/lib/firmware/\$kernel_ver/device-tree/hamoa-iot-evk.dtb\"
 


### PR DESCRIPTION
### Summary

Update `build-ubuntu-rootfs.sh` to derive `kernel_ver` from the
`linux-kernel-*-arm64.deb` filename while stripping the CI
`run_id-run_attempt` suffix (e.g. `-19454794115-1`).

This ensures that `kernel_ver` matches the actual kernel release version
used by `uname -r` and `/lib/modules`, rather than the CI-specific
package name.

### Details

- Use `basename "$KERNEL_DEB"` to ignore any leading path components.
- Extract the version between `linux-kernel-` and `-arm64.deb`.
- Remove an optional trailing `-[digits]-[digits]` segment corresponding
  to the CI `run_id-run_attempt` suffix.
- Keep behavior compatible with both:
  - `linux-kernel-6.18.0-rc5-arm64.deb`
  - `linux-kernel-6.18.0-rc5-19454794115-1-arm64.deb`

After this change, `kernel_ver` resolves to `6.18.0-rc5` in both cases,
which aligns with:

- `uname -r`
- `/lib/modules/<kernel_ver>`
- DTB paths under `/lib/firmware/<kernel_ver>/device-tree/...`

### Rationale

Previously, when the CI started appending `run_id-run_attempt` to the
package name, `kernel_ver` inherited that suffix, leading to a mismatch
between the GRUB DTB paths and the actual kernel release directory
layout on the rootfs.

Normalizing `kernel_ver` to the release version restores the expected
behavior for boot configuration and firmware/DTB resolution.

### Testing

- Verified `kernel_ver` extraction locally with:
  - `linux-kernel-6.18.0-rc5-arm64.deb`
  - `linux-kernel-6.18.0-rc5-19454794115-1-arm64.deb`
- Confirmed both resolve to `6.18.0-rc5`.
