### PR TITLE
Add build-dtb-image.sh for combined DTB FAT image generation

### DIFF
--- a/kernel/scripts/build-dtb-image.sh
+++ b/kernel/scripts/build-dtb-image.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+#
+# =============================================================================
+# build-dtb-image.sh
+#
+# Description:
+#   Build a FAT-formatted image containing a single *combined* Device Tree
+#   Blob (DTB) file for Qualcomm-based ARM64 platforms.
+#
+#   This script:
+#     1. Reads a manifest file listing DTB filenames (one per line).
+#     2. Normalizes entries to absolute paths under the specified DTB source
+#        directory (unless already absolute).
+#     3. Validates that all DTB files exist.
+#     4. Concatenates all DTBs (in manifest order) into a single combined
+#        DTB file: <DTB_SRC>/combined-dtb.dtb
+#     5. Creates a FAT image of configurable size.
+#     6. Mounts the FAT image via a loop device and copies the combined DTB
+#        into the image.
+#
+# Usage:
+#   ./build-dtb-image.sh -dtb-src <path> -manifest <file> [-size <MB>] [-out <file>]
+#
+# Arguments:
+#   -dtb-src   Path to DTB source directory
+#              e.g., arch/arm64/boot/dts/qcom
+#
+#   -manifest  Path to manifest file listing DTBs (one per line). Each line:
+#                - may be relative to -dtb-src, OR
+#                - an absolute path to a .dtb file.
+#              Blank lines and lines starting with '#' are ignored.
+#
+#   -size      FAT image size in MB (integer > 0, default: 4)
+#
+#   -out       Output image filename (default: dtb.bin)
+#
+# Requirements / Assumptions:
+#   - Linux host with:
+#       * bash
+#       * mkfs.vfat
+#       * losetup
+#       * mount / umount
+#       * dd (with status=progress support is nice but not required)
+#   - sudo access for:
+#       * losetup
+#       * mkfs.vfat
+#       * mount / umount
+#
+# Notes:
+#   - The combined DTB is written to: <DTB_SRC>/combined-dtb.dtb
+#   - The resulting FAT image contains exactly one file: combined-dtb.dtb
+#     in the root directory of the filesystem.
+#   - The script installs a cleanup trap to:
+#       * unmount the image,
+#       * detach the loop device,
+#       * delete temporary files and directories.
+#
+# =============================================================================
+
+set -euo pipefail
+
+# ----------------------------- Defaults --------------------------------------
+
+DTB_BIN_SIZE=4         # Default FAT image size (MB)
+DTB_BIN="dtb.bin"      # Default output image filename
+
+DTB_SRC=""             # DTB source directory (required)
+DTB_LIST=""            # Manifest file (required)
+
+SANLIST=""             # Will hold the path to the sanitized DTB list
+MNT_DIR=""             # Temporary mount directory
+LOOP_DEV=""            # Loop device used for the FAT image
+
+# ---------------------------- Helper Functions -------------------------------
+
+usage() {
+    cat <<EOF
+Usage: $0 -dtb-src <path> -manifest <file> [-size <MB>] [-out <file>]
+
+  -dtb-src   Path to DTB source directory (e.g. arch/arm64/boot/dts/qcom)
+  -manifest  Path to manifest file listing DTBs (one per line)
+  -size      FAT image size in MB (default: 7)
+  -out       Output image filename (default: dtb.bin)
+EOF
+    exit 1
+}
+
+cleanup() {
+    # Preserve the original exit status so we can exit with the right code
+    local status=$?
+
+    # Ensure any buffered writes are flushed (best-effort)
+    sync || true
+
+    # Unmount the mountpoint if it exists and is currently mounted
+    if [[ -n "${MNT_DIR:-}" && -d "$MNT_DIR" ]]; then
+        if mountpoint -q "$MNT_DIR"; then
+            sudo umount "$MNT_DIR" || true
+        fi
+        # Try to remove the temporary directory (ignore failures)
+        rmdir "$MNT_DIR" 2>/dev/null || true
+    fi
+
+    # Detach loop device if it was created
+    if [[ -n "${LOOP_DEV:-}" ]]; then
+        sudo losetup -d "$LOOP_DEV" || true
+    fi
+
+    # Remove temporary sanitized list
+    if [[ -n "${SANLIST:-}" && -f "$SANLIST" ]]; then
+        rm -f "$SANLIST"
+    fi
+
+    exit "$status"
+}
+
+# Install trap early to handle failures after we start creating resources.
+trap cleanup EXIT
+
+# ------------------------------ Arg Parsing ----------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -dtb-src)
+            DTB_SRC="${2:-}"
+            shift 2
+            ;;
+        -manifest)
+            DTB_LIST="${2:-}"
+            shift 2
+            ;;
+        -size)
+            DTB_BIN_SIZE="${2:-}"
+            shift 2
+            ;;
+        -out)
+            DTB_BIN="${2:-}"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+# ----------------------------- Validation ------------------------------------
+
+# Require mandatory arguments
+if [[ -z "$DTB_SRC" || -z "$DTB_LIST" ]]; then
+    echo "ERROR: -dtb-src and -manifest are required." >&2
+    usage
+fi
+
+# Validate manifest exists
+if [[ ! -f "$DTB_LIST" ]]; then
+    echo "ERROR: Manifest file '$DTB_LIST' not found." >&2
+    exit 1
+fi
+
+# Validate DTB source directory
+if [[ ! -d "$DTB_SRC" ]]; then
+    echo "ERROR: DTB source directory '$DTB_SRC' not found." >&2
+    exit 1
+fi
+
+# Validate image size is a positive integer
+if ! [[ "$DTB_BIN_SIZE" =~ ^[0-9]+$ ]] || (( DTB_BIN_SIZE <= 0 )); then
+    echo "ERROR: -size must be a positive integer (MB), got '$DTB_BIN_SIZE'." >&2
+    exit 1
+fi
+
+# --------------------------- Sanitize Manifest -------------------------------
+
+# Temporary file to hold the fully-qualified DTB paths
+SANLIST="$(mktemp -t dtb-list-XXXXXX)"
+
+# Normalize manifest lines:
+#   - Skip blank lines
+#   - Skip comment lines starting with '#'
+#   - If the entry is absolute, keep as-is
+#   - Otherwise, prefix with DTB_SRC
+awk -v src="$DTB_SRC" '
+  /^[[:space:]]*$/ {next}    # skip blank lines
+  /^[[:space:]]*#/ {next}    # skip comments
+  {
+    if ($0 ~ /^\//) print $0;
+    else            print src "/" $0;
+  }
+' "$DTB_LIST" > "$SANLIST"
+
+# Ensure that the manifest produced at least one valid entry
+if [[ ! -s "$SANLIST" ]]; then
+    echo "ERROR: Manifest '$DTB_LIST' has no valid DTB entries (non-comment, non-empty)." >&2
+    exit 1
+fi
+
+# Validate each DTB exists
+while IFS= read -r f; do
+    if [[ ! -f "$f" ]]; then
+        echo "ERROR: Missing DTB: $f" >&2
+        exit 1
+    fi
+done < "$SANLIST"
+
+# -------------------------- Combine DTBs -------------------------------------
+
+OUT="${DTB_SRC}/combined-dtb.dtb"
+rm -f "$OUT"
+
+# Concatenate in the order specified by the sanitized manifest.
+# xargs -a is GNU-specific but acceptable for typical Linux build hosts.
+xargs -a "$SANLIST" -r cat > "$OUT"
+echo "[INFO] Combined DTBs into: $OUT"
+ls -lh "$OUT"
+
+# -------------------------- Create FAT Image ---------------------------------
+
+echo "[INFO] Creating FAT image '$DTB_BIN' (${DTB_BIN_SIZE} MB)..."
+dd if=/dev/zero of="$DTB_BIN" bs=1M count="$DTB_BIN_SIZE" status=progress
+
+# Attach a loop device to the image
+LOOP_DEV="$(sudo losetup --show -fP "$DTB_BIN")"
+echo "[INFO] Using loop device: $LOOP_DEV"
+
+# Create a temporary mount directory for this run
+MNT_DIR="$(mktemp -d -t dtb-mnt-XXXXXX)"
+
+# Format the loop device with FAT
+echo "[INFO] Formatting $LOOP_DEV as FAT..."
+sudo mkfs.vfat "$LOOP_DEV" >/dev/null
+
+# Mount the loop device
+echo "[INFO] Mounting $LOOP_DEV at $MNT_DIR..."
+sudo mount "$LOOP_DEV" "$MNT_DIR"
+
+# ----------------------- Deploy Combined DTB ---------------------------------
+
+sudo cp "$OUT" "$MNT_DIR/"
+echo "[INFO] Deployed combined DTB into FAT image."
+echo "[INFO] Files in image:"
+ls -lh "$MNT_DIR"
+
+# Normal exit (cleanup will still run, but now everything should succeed).
+exit 0


### PR DESCRIPTION
## Summary

Introduce `build-dtb-image.sh`, a standalone tool to generate a
FAT-formatted image containing a single combined DTB for Qualcomm-based
ARM64 platforms. The tool consumes a manifest of DTBs, validates and
concatenates them into a single `combined-dtb.dtb`, and packages that
artifact into a minimal FAT image suitable for boot flows and CI
pipelines.

## Details

### Inputs and manifest handling

The script is driven by two required inputs:

- `-dtb-src`: DTB source directory (e.g. `arch/arm64/boot/dts/qcom`)
- `-manifest`: manifest file listing DTB filenames (one per line)

Key behaviors:

- Manifest entries may be:
  - Absolute paths to `.dtb` files, or
  - Relative paths resolved against `-dtb-src`.
- Blank lines and lines starting with `#` are ignored.
- Entries are normalized into a temporary sanitized list:
  - Stored in a `mktemp`-generated file.
  - Used as the single source of truth for subsequent validation and
    concatenation.

Validation performed:

- The manifest file must exist and produce at least one valid DTB entry
  (non-empty, non-comment).
- Every DTB path in the sanitized list must exist on disk.
- The `-size` argument, if provided, must be a positive integer (MB).

### Combined DTB generation

After sanitization and validation, the script:

- Concatenates all DTBs in manifest order into:
  - `<DTB_SRC>/combined-dtb.dtb`
- Uses `xargs -a` to preserve ordering and avoid unnecessary subshells.
- Logs the resulting file (size and path) for traceability.

This keeps a deterministic combined DTB artifact in the DTB source tree
while providing a single binary blob for downstream consumers.

### FAT image creation and layout

The tool then creates a FAT filesystem image and deploys the combined
DTB:

- Image size:
  - Configurable via `-size` (MB).
  - Defaults to **4 MB**.
- Implementation details:
  - Uses `dd` to create a zeroed image file of the requested size.
  - Attaches it to a loop device via `losetup --show -fP`.
  - Formats the loop device with `mkfs.vfat`.
  - Mounts the device on a `mktemp`-generated mount directory.
  - Copies `combined-dtb.dtb` into the root of the FAT filesystem.

Resulting layout inside the FAT image:

- `/combined-dtb.dtb` only (no additional files or directories).

This keeps the on-image structure minimal and unambiguous for boot
firmware or test infrastructure.

### Robust cleanup and error handling

To avoid leaking loop devices or mountpoints and to make the tool safe
for CI and repeated local use, the script:

- Installs a global `EXIT` trap at startup.
- Implements a `cleanup()` routine that:
  - Preserves and re-uses the original process exit status.
  - Runs `sync` best-effort before teardown.
  - Unmounts the temporary mountpoint **only if** it exists and is
    currently mounted (`mountpoint -q`).
  - Detaches the loop device **only if** it was successfully created.
  - Removes the temporary mount directory and sanitized manifest file
    if present.

With `set -euo pipefail` and these guards in place, the script:

- Fails fast on invalid input or failed system calls.
- Leaves the system in a clean state (no dangling loop devices or
  stale mountpoints) even on error paths.

## Usage

Basic example:

```bash
./build-dtb-image.sh \
  -dtb-src arch/arm64/boot/dts/qcom \
  -manifest dtb-manifest \
  -size 4 \
  -out dtb.bin
