### PR TITLE
build_kernel.sh: deploy all DTBs to out/ for .deb packaging

### DIFF
--- a/kernel/scripts/build_kernel.sh
+++ b/kernel/scripts/build_kernel.sh
@@ -11,16 +11,17 @@
 # Author: Bjordis Collaku <bcollaku@qti.qualcomm.com>
 # ===================================================
 
-kpath=$BUILD_TOP/qcom-next/arch/arm64/boot
+treedir=${1:-$BUILD_TOP/qcom-next/}
+kpath="$(cd "$treedir" && pwd)/arch/arm64/boot"
 
 # Clean previous build
 rm -rf $BUILD_TOP/out/*;
 
 # Make config
-cd $BUILD_TOP/qcom-next/
+cd $treedir
 make ARCH=arm64 defconfig qcom.config
 # Deploy boot config to out/
-cp $BUILD_TOP/qcom-next/.config $BUILD_TOP/out/
+cp $treedir/.config $BUILD_TOP/out/
 
 # Make kernel
 make ARCH=arm64 -j32;


### PR DESCRIPTION
**Summary**  
Deploy all device tree blobs (DTBs) by recursively collecting every `*.dtb` under `arch/arm64/boot/dts` into `out/`. This ensures the kernel packaging script can pick up the complete DTB set when building the `.deb`, eliminating misses from a hardcoded list.

**Changes**

*   Replace explicit DTB deployment lines with a safe recursive deployment:
    ```bash
    find "$kpath/dts" -type f -name '*.dtb' -print0 | xargs -0 -I{} cp "{}" "$BUILD_TOP/out/"
    ```

**Rationale**

*   Automatically includes DTBs for newly added boards without script updates.
*   Reduces maintenance overhead and risk of missing artifacts.

**Behavior Notes**

*   DTBs are deployed into a **flat** `out/` directory.
*   Kernel image and module build/install steps remain unchanged.
