### PR TITLE
Fix tarball naming: correctly replace .changes with .tar.gz

### DIFF
--- a/scripts/create_data_tar.py
+++ b/scripts/create_data_tar.py
@@ -182,7 +182,7 @@ def main():
     # Create tarball named after the .changes file (e.g., pkg_1.0_arm64.tar.gz)
     try:
         base = os.path.basename(changes_path)
-        tar_name = re.sub(r'\\.changes$', '.tar.gz', base)
+        tar_name = re.sub(r'\.changes$', '.tar.gz', base)
         if tar_name == base:
             tar_name = base + '.tar.gz'
         tar_path = create_tar_of_data(work_dir, tar_name)


### PR DESCRIPTION
Fix tarball name generation by correctly replacing .changes extension The previous regex used \\. which did not match .changes, causing filenames like …_arm64.changes.tar.gz. Updated pattern to properly strip .changes and produce the expected .tar.gz artifact name.