### PR TITLE
build-rootfs: Transition from custom GRUB config to upstream standard (update-grub)

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -568,6 +568,32 @@ sed -i 's/root=\/dev\/[^ ]* //g' /boot/grub/grub.cfg
 # 3. Legacy Compatibility
 # Create a relative symlink for bootloaders expecting the old path.
 ln -sf grub/grub.cfg /boot/grub.cfg
+
+# ==============================================================================
+# Device Tree Configuration for Debian platforms
+# ==============================================================================
+
+if [ \"\${distro_lc}\" = \"debian\" ]; then
+    echo '[INFO][CHROOT] Debian target detected. Configuring platform Device Tree...'
+
+    # Locate the platform Device Tree Blob (DTB) in standard library or firmware paths
+    DTB_PATH=\$(find /usr/lib /lib/firmware -name \"glymur-crd.dtb\" -print -quit)
+
+    if [ -n \"\$DTB_PATH\" ]; then
+        echo \"[INFO][CHROOT] Platform DTB resolved: \$DTB_PATH\"
+        
+        # Ensure DTB is accessible in the bootloader's filesystem scope
+        ln -sf \"\$DTB_PATH\" /boot/dtb
+        
+        # Inject the devicetree directive into the generated GRUB configuration.
+        # This appends the command immediately following the 'initrd' load.
+        sed -i \"/^[[:space:]]*initrd/a \    devicetree /boot/dtb\" /boot/grub/grub.cfg
+        
+        echo '[SUCCESS][CHROOT] Device Tree directive injected into /boot/grub/grub.cfg'
+    else
+        echo '[WARN][CHROOT] Target DTB (glymur-crd.dtb) not found. Skipping injection.'
+    fi
+fi
 "
 
 # ==============================================================================


### PR DESCRIPTION
### Overview
This PR completely refactors the bootloader configuration logic in `build-rootfs.sh`. It abandons the manual, static construction of `grub.cfg` in favor of the standard Debian `update-grub` mechanism. This ensures robust compatibility with upstream kernel packages and automated menu generation.

The PR encompasses the definition of critical boot defaults (Step 7.5), the isolation of host vs. target environment variables, and a post-processing stage to ensure the generated image remains generic and portable despite being built on a host machine.

### Detailed Changes

#### 1. Configuration & Defaults (Step 7.5)
* **New Configuration Step:** Introduced Step 7.5 to programmatically generate `/etc/default/grub` prior to the chroot phase.
* **Boot Parameters:** Defined `GRUB_CMDLINE_LINUX` with critical hardware settings (`earlycon`, `console=ttyMSM0`, `efi=noruntime`) ensuring these apply to both **Normal** and **Recovery** boot modes.
* **Root Filesystem Addressing:** Set `GRUB_DISABLE_LINUX_UUID=true` and enforced `root=LABEL=system`. This prepares the config for generic booting, ensuring the kernel does not rely on specific partition block UUIDs.
* **Host Isolation:** Implemented the quoted heredoc syntax (`cat <<'EOF'`) for writing the config file. This ensures that backticked commands (like `` `lsb_release` ``) are written literally to the file for execution inside the target, preventing accidental expansion/execution by the build host shell.
* **Directory Safety:** Added explicit `mkdir -p` commands for `/boot/grub` and `/etc/default`. This resolves race conditions where `update-grub` (triggered by package installs) would fail due to missing directory structures.

#### 2. Standardization & Lifecycle (Step 8)
* **Adoption of update-grub:** Replaced the brittle manual `cat > grub.cfg` logic with the standard `update-grub` toolchain.
* **Dependency Management:** Added `grub-common`, `grub2-common`, and `lsb-release` to the debootstrap seed list to ensure generation tools are present in the baseline rootfs.
* **Redundancy Cleanup:** Removed the manual kernel version parsing logic (`kernel_ver`) and the explicit `update-grub` call in Step 8. We now delegate configuration generation entirely to the kernel package's `postinst` hook, which executes `update-grub` immediately after installation. This aligns the build process with standard Debian package lifecycle events.

#### 3. Post-Processing & Sanitization
Because `update-grub` runs inside a chroot on the build host, it inherently "leaks" host-specific details. We added a sanitization layer to scrub these artifacts:
* **Enforce Label-Based Search:** Implemented `sed` logic to strip host-detected UUID searches (`search --fs-uuid ...`) and replace them with `search --label system`. This ensures the bootloader can locate the kernel on any storage medium (SD, eMMC, NVMe).
* **Remove Host Device Paths:** Added logic to scrub host-specific root paths (e.g., `/dev/nvme0n1p1`) that `grub-probe` incorrectly detects from the build server, strictly enforcing the generic `root=LABEL=system` argument.
* **Relative Symlink:** Updated the legacy `/boot/grub.cfg` compatibility link to use a relative path (`grub/grub.cfg`) instead of an absolute one, ensuring correct file resolution both during runtime and when the rootfs is mounted on a host machine for inspection.