### PR TITLE
Migrating to ARM64 github runners only

### DIFF
--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -38,10 +38,6 @@ on:
         type: boolean
         default: false
 
-    secrets:
-      TOKEN:
-        required: true
-
 permissions:
   contents: read
 
@@ -64,7 +60,7 @@ jobs:
       options: --privileged
       credentials:
         username: ${{vars.DEB_PKG_BOT_CI_USERNAME}}
-        password: ${{secrets.TOKEN}}
+        password: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 
     steps:
 
@@ -73,7 +69,7 @@ jobs:
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./qcom-build-utils
           fetch-depth: 1
           sparse-checkout: |
@@ -84,7 +80,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{inputs.debian-ref}}
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./package-repo
           fetch-depth: 0 # <- Important for the tags fetching to work
           fetch-tags: true # <- Important
@@ -109,4 +105,4 @@ jobs:
         with:
           distro-codename: ${{inputs.distro-codename}}
           force-override: false
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}

--- a/.github/workflows/qcom-promote-upstream-reusable-workflow.yml
+++ b/.github/workflows/qcom-promote-upstream-reusable-workflow.yml
@@ -31,10 +31,6 @@ on:
         type: string
         required: true
 
-    secrets:
-      TOKEN:
-        required: true
-
 permissions:
   contents: write
 
@@ -58,7 +54,7 @@ jobs:
       image: ghcr.io/qualcomm-linux/pkg-builder:arm64-noble
       credentials:
         username: ${{ vars.DEB_PKG_BOT_CI_USERNAME }}
-        password: ${{ secrets.TOKEN }}
+        password: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
 
     steps:
 
@@ -88,7 +84,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./package-repo
           fetch-depth: 0
 
@@ -142,7 +138,7 @@ jobs:
           echo "ℹ️ This is likely a second attempt to promote the same upstream tag, where the first attempt already added the upstream tag in the upstram branch"
 
           # Check if there is a PR open for this already
-          gh auth login --with-token <<< "${{secrets.TOKEN}}"
+          gh auth login --with-token <<< "${{secrets.DEB_PKG_BOT_CI_TOKEN}}"
           PRS=$(gh pr list --head "debian/pr/${{env.NORMALIZED_VERSION}}-1" --state open --json number --jq '.[].number')
           if [ -n "$PRS" ]; then
             echo "❌ An open PR already exists for this promotion attempt: $PRS"
@@ -169,7 +165,7 @@ jobs:
       - name: Add Upstream Link As A Remote And Fetch Tags
         run: |
           cd ./package-repo
-          git remote add upstream-source https://x-access-token:${{secrets.TOKEN}}@github.com/${{inputs.upstream-repo}}.git
+          git remote add upstream-source https://x-access-token:${{secrets.DEB_PKG_BOT_CI_TOKEN}}@github.com/${{inputs.upstream-repo}}.git
           git fetch upstream-source "+refs/tags/*:refs/tags/*"
 
       - name: Ensure the tag exists in the upstream repo
@@ -246,7 +242,7 @@ jobs:
         run: |
           cd ./package-repo
 
-          gh auth login --with-token <<< "${{secrets.TOKEN}}"
+          gh auth login --with-token <<< "${{secrets.DEB_PKG_BOT_CI_TOKEN}}"
 
           ../qcom-build-utils/scripts/create_promotion_pr.py \
             --base-branch "${{inputs.debian-branch}}" \

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -30,12 +30,6 @@ on:
         type: boolean
         default: true
 
-    secrets:
-      TOKEN:
-        required: true
-      QSC_TOKEN:
-        required: true
-
 permissions:
   contents: read
 
@@ -57,7 +51,7 @@ jobs:
       options: --privileged
       credentials:
         username: ${{vars.DEB_PKG_BOT_CI_USERNAME}}
-        password: ${{secrets.TOKEN}}
+        password: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 
     steps:
 
@@ -75,7 +69,7 @@ jobs:
       - name: Checkout Packaging Repo
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./package-repo
           fetch-depth: 0
           fetch-tags: true
@@ -296,7 +290,7 @@ jobs:
       - name: Notify qcom-distro-images of new release via repository dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           repository: qualcomm-linux/qcom-distro-images
           event-type: pkg-repo-release
           client-payload: >-

--- a/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml
+++ b/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml
@@ -39,10 +39,6 @@ on:
         type: string
         default: noble
 
-    secrets:
-      TOKEN:
-        required: true
-
 permissions:
   contents: read
 
@@ -68,7 +64,7 @@ jobs:
       options: --privileged
       credentials:
         username: ${{vars.DEB_PKG_BOT_CI_USERNAME}}
-        password: ${{secrets.TOKEN}}
+        password: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 
     steps:
 
@@ -88,7 +84,7 @@ jobs:
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./qcom-build-utils
           fetch-depth: 1
           sparse-checkout: |
@@ -100,7 +96,7 @@ jobs:
         with:
           repository: ${{inputs.pkg-repo}}
           clean: false
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./package-repo
           fetch-depth: 0
           fetch-tags: true
@@ -111,7 +107,7 @@ jobs:
           repository: ${{inputs.upstream-repo}}
           ref: ${{inputs.upstream-repo-ref}}
           clean: false
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./upstream-repo
           fetch-depth: 0
 


### PR DESCRIPTION
This PR removes the runners selection altogether. Before this, a user could pass a runners selection because at the time github only provided amd64 runenrs, and we had what seemed to be working amd64 cross-compilation. Now that github released native arm64 machines and the amd64 cross-compilation docker-pkg-build proved to be not reliable, the decision to drop amd64 altogether has been made. 

This removes runner selection to ensure there is only one way of doing things, which is native arm64 builds and that is dictated by the reulsable workflows themselves