### PR TITLE
Build ARM64 ESP as standalone BOOTAA64.EFI (efi.bin) via grub-mkstandalone

### DIFF
--- a/bootloader/build-efi-esp.sh
+++ b/bootloader/build-efi-esp.sh
@@ -21,7 +21,7 @@
 #
 # Embedded bootstrap config behavior:
 #   - Search root filesystem by label "system"
-#   - Chainload rootfs GRUB config: ($root)/boot/grub/grub.cfg (or /boot/grub.cfg)
+#   - Chainload rootfs GRUB config: ($root)/boot/grub/grub.cfg
 #
 # Usage:
 #   ./build-efi-esp.sh [--sector-size <size>] [--esp-size-mb <mb>] [--no-install]
@@ -212,10 +212,8 @@ search --no-floppy --label ${ROOT_LABEL} --set=root
 if [ -e (\$root)/boot/grub/grub.cfg ]; then
   set prefix=(\$root)/boot/grub
   configfile (\$root)/boot/grub/grub.cfg
-elif [ -e (\$root)/boot/grub.cfg ]; then
-  configfile (\$root)/boot/grub.cfg
 else
-  echo 'ERROR: Rootfs found but no GRUB config at /boot/grub/grub.cfg or /boot/grub.cfg'
+  echo 'ERROR: Rootfs found but no GRUB config at /boot/grub/grub.cfg'
   echo 'Dropping to GRUB shell.'
 fi
 EOF

--- a/bootloader/build-efi-esp.sh
+++ b/bootloader/build-efi-esp.sh
@@ -7,26 +7,33 @@
 # Script: build-efi-esp.sh
 # ------------------------------------------------------------------------------
 # Description:
-#   Creates a standalone EFI System Partition image (efiesp.bin) for ARM64
-#   platforms with configurable sector size.
+#   Creates a standalone EFI System Partition filesystem image (efi.bin)
+#   for ARM64 platforms with configurable FAT sector size.
 #
-#   Workflow:
-#     1. **Auto‑elevate** – re‑executes itself with `sudo` if not already root.
-#     2. **Install tooling** – `grub-efi-arm64-bin`, `grub2-common`, `dosfstools`.
-#     3. **Allocate** a blank file (size depends on sector size) and format it
-#        FAT32 with specified sector size (default: 512).
-#     4. **Loop‑attach** the image and install GRUB for the arm64‑efi target
-#        in *removable* mode (no NVRAM writes).
-#     5. **Seed** a minimal `grub.cfg` that chain‑loads the main GRUB on
-#        the rootfs partition (assumed GPT 13).
-#     6. **Cleanup** – unmount, detach loop device, and report success.
+# Key design goals:
+#   - Deterministic/reproducible: avoid `grub-install` and install-layout coupling.
+#   - Self-contained bootloader: generate a standalone `BOOTAA64.EFI` that embeds
+#     a tiny bootstrap config and required GRUB modules.
+#   - Single source of truth for the real menu: rootfs `/boot/grub/grub.cfg`.
+#
+# Resulting ESP contents:
+#   /EFI/BOOT/BOOTAA64.EFI   (standalone GRUB for ARM64 UEFI, removable path)
+#
+# Embedded bootstrap config behavior:
+#   - Search root filesystem by label "system"
+#   - Chainload rootfs GRUB config: ($root)/boot/grub/grub.cfg (or /boot/grub.cfg)
 #
 # Usage:
-#   ./build-efi-esp.sh [--sector-size <size>]
-#     Example: ./build-efi-esp.sh --sector-size 4096
+#   ./build-efi-esp.sh [--sector-size <size>] [--esp-size-mb <mb>] [--no-install]
+#                     [--root-label <label>] [--out <efi.bin>]
+#
+# Examples:
+#   ./build-efi-esp.sh
+#   ./build-efi-esp.sh --sector-size 4096
+#   ./build-efi-esp.sh --no-install
 #
 # Output:
-#   efiesp.bin  → flash to appropriate ESP partition
+#   efi.bin  → write/flash to an ESP partition (FAT32)
 #
 # Author: Bjordis Collaku <bcollaku@qti.qualcomm.com>
 # ==============================================================================
@@ -34,92 +41,225 @@
 set -euo pipefail
 
 # ==============================================================================
-# Step 0  Auto‑elevate if not run as root
+# Step 0  Auto-elevate if not run as root
 # ==============================================================================
-if [[ "$EUID" -ne 0 ]]; then
-    echo "[INFO] Re‑running script as root using sudo…"
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "[INFO] Re-running script as root using sudo..."
     exec sudo "$0" "$@"
 fi
 
 # ==============================================================================
-# Step 1  Configuration
+# Step 1  Defaults
 # ==============================================================================
-ESP_IMG="efiesp.bin"
+OUT_IMG="efi.bin"
 ESP_SIZE_MB=200
-MNT_DIR="mnt"
-SECTOR_SIZE=512  # Default sector size
+SECTOR_SIZE=512
+ROOT_LABEL="system"
+NO_INSTALL=0
 
-# Parse optional argument
+WORKDIR="$(pwd)"
+MNT_DIR="$(mktemp -d -p "${WORKDIR}" efiesp.mnt.XXXXXX)"
+LOOP_DEV=""
+
+cleanup() {
+    set +e
+    if mountpoint -q "${MNT_DIR}"; then
+        umount -l "${MNT_DIR}" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${LOOP_DEV}" ]]; then
+        losetup -d "${LOOP_DEV}" >/dev/null 2>&1 || true
+    fi
+    rm -rf "${MNT_DIR}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+print_usage() {
+    cat <<EOF
+Usage:
+  $0 [--sector-size <bytes>] [--esp-size-mb <mb>] [--root-label <label>]
+     [--out <efi.bin>] [--no-install] [-h|--help]
+
+Notes:
+  - Produces a FAT32 filesystem image (no GPT inside the file).
+  - Installs a standalone ARM64 GRUB as /EFI/BOOT/BOOTAA64.EFI using grub-mkstandalone.
+  - At boot, GRUB searches for rootfs by LABEL and loads its /boot/grub/grub.cfg.
+
+EOF
+}
+
+# ==============================================================================
+# Step 2  Parse args (named, strict)
+# ==============================================================================
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --sector-size)
-            SECTOR_SIZE="$2"
-            shift 2
-            ;;
+            SECTOR_SIZE="${2-}"; shift 2 ;;
+        --esp-size-mb)
+            ESP_SIZE_MB="${2-}"; shift 2 ;;
+        --root-label)
+            ROOT_LABEL="${2-}"; shift 2 ;;
+        --out)
+            OUT_IMG="${2-}"; shift 2 ;;
+        --no-install)
+            NO_INSTALL=1; shift ;;
+        -h|--help)
+            print_usage; exit 0 ;;
         *)
             echo "[ERROR] Unknown argument: $1"
-            exit 1
-            ;;
+            print_usage
+            exit 1 ;;
     esac
 done
 
-# Adjust ESP size for 4096-byte sector case
-if [[ "$SECTOR_SIZE" -eq 4096 ]]; then
-    ESP_SIZE_MB=300
-    echo "[INFO] Sector size is 4096; adjusting ESP size to ${ESP_SIZE_MB} MB for FAT32 compliance."
+# ==============================================================================
+# Step 3  Validate inputs
+# ==============================================================================
+if [[ -z "${SECTOR_SIZE}" || -z "${ESP_SIZE_MB}" || -z "${ROOT_LABEL}" || -z "${OUT_IMG}" ]]; then
+    echo "[ERROR] One or more required values were empty."
+    exit 1
 fi
 
-echo "[INFO] Using sector size: ${SECTOR_SIZE}"
+if ! [[ "${SECTOR_SIZE}" =~ ^[0-9]+$ ]]; then
+    echo "[ERROR] --sector-size must be an integer, got: ${SECTOR_SIZE}"
+    exit 1
+fi
+
+case "${SECTOR_SIZE}" in
+    512|1024|2048|4096) ;;
+    *)
+        echo "[ERROR] Unsupported sector size: ${SECTOR_SIZE}. Expected one of: 512,1024,2048,4096"
+        exit 1 ;;
+esac
+
+if ! [[ "${ESP_SIZE_MB}" =~ ^[0-9]+$ ]]; then
+    echo "[ERROR] --esp-size-mb must be an integer, got: ${ESP_SIZE_MB}"
+    exit 1
+fi
+
+# FAT32 sizing guidance for large sectors: keep cluster count in valid range.
+# Empirically, 300MB works well for 4K sector ESPs on many firmwares/tools.
+if [[ "${SECTOR_SIZE}" -eq 4096 && "${ESP_SIZE_MB}" -lt 300 ]]; then
+    echo "[INFO] Sector size is 4096; bumping ESP size to 300MB for FAT32 compliance."
+    ESP_SIZE_MB=300
+fi
+
+echo "[INFO] Output image: ${OUT_IMG}"
+echo "[INFO] ESP size: ${ESP_SIZE_MB} MB"
+echo "[INFO] FAT sector size: ${SECTOR_SIZE}"
+echo "[INFO] Rootfs label: ${ROOT_LABEL}"
 
 # ==============================================================================
-# Step 2  Install Required Packages
+# Step 4  Ensure required host tools exist (optionally install)
 # ==============================================================================
-echo "[INFO] Installing required packages…"
-apt-get update -y
-apt-get install -y grub2-common grub-efi-arm64-bin dosfstools
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || return 1
+}
+
+missing=()
+for c in dd losetup mkfs.vfat mount umount; do
+    need_cmd "${c}" || missing+=("${c}")
+done
+
+# GRUB tooling: we require arm64-efi platform modules + grub-mkstandalone
+for c in grub-mkstandalone; do
+    need_cmd "${c}" || missing+=("${c}")
+done
+
+if [[ "${#missing[@]}" -gt 0 ]]; then
+    echo "[INFO] Missing commands: ${missing[*]}"
+    if [[ "${NO_INSTALL}" -eq 1 ]]; then
+        echo "[ERROR] --no-install specified and required tools are missing."
+        exit 1
+    fi
+
+    echo "[INFO] Installing required packages (Debian/Ubuntu)..."
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -y
+    apt-get install -y grub-efi-arm64-bin grub2-common dosfstools util-linux
+fi
+
+# Verify that arm64-efi GRUB platform dir exists (common failure in containers)
+# Typical locations:
+#   /usr/lib/grub/arm64-efi
+#   /usr/share/grub/arm64-efi  (less common)
+GRUB_PLATFORM_DIR=""
+if [[ -d /usr/lib/grub/arm64-efi ]]; then
+    GRUB_PLATFORM_DIR="/usr/lib/grub/arm64-efi"
+elif [[ -d /usr/share/grub/arm64-efi ]]; then
+    GRUB_PLATFORM_DIR="/usr/share/grub/arm64-efi"
+fi
+
+if [[ -z "${GRUB_PLATFORM_DIR}" ]]; then
+    echo "[ERROR] GRUB arm64-efi modules directory not found."
+    echo "        Expected /usr/lib/grub/arm64-efi (or /usr/share/grub/arm64-efi)."
+    echo "        In Docker, ensure you install grub-efi-arm64-bin for the target arch."
+    exit 1
+fi
+echo "[INFO] GRUB platform dir: ${GRUB_PLATFORM_DIR}"
 
 # ==============================================================================
-# Step 3  Create and Format ESP Image
+# Step 5  Build standalone BOOTAA64.EFI (self-contained + embedded bootstrap)
 # ==============================================================================
-echo "[INFO] Creating ${ESP_SIZE_MB} MB EFI System Partition image: ${ESP_IMG}"
-dd if=/dev/zero of="${ESP_IMG}" bs=1M count="${ESP_SIZE_MB}" status=progress
+BOOTSTRAP_CFG="$(mktemp -p "${WORKDIR}" efiesp.bootstrap.XXXXXX.cfg)"
+cat > "${BOOTSTRAP_CFG}" <<EOF
+# Embedded bootstrap grub.cfg (inside BOOTAA64.EFI)
+set default=0
+set timeout=0
 
-LOOP_DEV=$(losetup --show -fP "${ESP_IMG}")
-echo "[INFO] Loop device attached: ${LOOP_DEV}"
+# Prefer label-based discovery for portability
+search --no-floppy --label ${ROOT_LABEL} --set=root
 
-echo "[INFO] Formatting as FAT32 with sector size ${SECTOR_SIZE}…"
-mkfs.vfat -F 32 -S "${SECTOR_SIZE}" "${LOOP_DEV}"
-
-# ==============================================================================
-# Step 4  Install GRUB to ESP Image
-# ==============================================================================
-mkdir -p "${MNT_DIR}"
-mount "${LOOP_DEV}" "${MNT_DIR}"
-mkdir -p "${MNT_DIR}/boot"
-
-echo "[INFO] Installing GRUB bootloader (arm64‑efi)…"
-grub-install \
-    --target=arm64-efi \
-    --efi-directory="${MNT_DIR}" \
-    --boot-directory="${MNT_DIR}/boot" \
-    --removable \
-    --no-nvram
-
-# ==============================================================================
-# Step 5  Write Bootstrap grub.cfg
-# ==============================================================================
-echo "[INFO] Writing bootstrap grub.cfg…"
-cat > "${MNT_DIR}/boot/grub/grub.cfg" <<EOF
-search --no-floppy --label system --set=root
-set prefix=(\$root)/boot/grub
-configfile /boot/grub.cfg
+if [ -e (\$root)/boot/grub/grub.cfg ]; then
+  set prefix=(\$root)/boot/grub
+  configfile (\$root)/boot/grub/grub.cfg
+elif [ -e (\$root)/boot/grub.cfg ]; then
+  configfile (\$root)/boot/grub.cfg
+else
+  echo 'ERROR: Rootfs found but no GRUB config at /boot/grub/grub.cfg or /boot/grub.cfg'
+  echo 'Dropping to GRUB shell.'
+fi
 EOF
 
+# A conservative module set for: GPT partitioning + FAT/ext + search + configfile + linux boot.
+# Add more (usb, nvme) if your firmware doesn't provide access to storage early enough.
+GRUB_MODULES="all_video boot btrfs cat chain configfile echo efi_gop efifwsetup ext2 fat font gettext gfxmenu gfxterm gfxterm_background gzio halt help hfsplus iso9660 jpeg keystatus loadenv linux lsefi lsefimmap lsefisystab lsmmap luks lvm mdraid09 mdraid1x memdisk minicmd normal part_gpt part_msdos png probe reboot regexp search search_fs_uuid search_label sleep test true video"
+
+STANDALONE_EFI="$(mktemp -p "${WORKDIR}" efiesp.BOOTAA64.XXXXXX.EFI)"
+echo "[INFO] Generating standalone BOOTAA64.EFI with embedded config..."
+grub-mkstandalone \
+    -O arm64-efi \
+    -o "${STANDALONE_EFI}" \
+    --modules="${GRUB_MODULES}" \
+    "boot/grub/grub.cfg=${BOOTSTRAP_CFG}"
+
+rm -f "${BOOTSTRAP_CFG}"
+
 # ==============================================================================
-# Step 6  Cleanup
+# Step 6  Create and format ESP image
 # ==============================================================================
+echo "[INFO] Creating ${ESP_SIZE_MB} MB ESP image..."
+dd if=/dev/zero of="${OUT_IMG}" bs=1M count="${ESP_SIZE_MB}" status=progress
+
+LOOP_DEV="$(losetup --show -fP "${OUT_IMG}")"
+echo "[INFO] Loop device attached: ${LOOP_DEV}"
+
+echo "[INFO] Formatting as FAT32 with sector size ${SECTOR_SIZE}..."
+mkfs.vfat -F 32 -S "${SECTOR_SIZE}" "${LOOP_DEV}" >/dev/null
+
+mount "${LOOP_DEV}" "${MNT_DIR}"
+
+# ==============================================================================
+# Step 7  Populate ESP (UEFI removable path)
+# ==============================================================================
+mkdir -p "${MNT_DIR}/EFI/BOOT"
+install -m 0644 "${STANDALONE_EFI}" "${MNT_DIR}/EFI/BOOT/BOOTAA64.EFI"
+rm -f "${STANDALONE_EFI}"
+
+sync
 umount -l "${MNT_DIR}"
 losetup -d "${LOOP_DEV}"
-rm -rf "${MNT_DIR}"
+LOOP_DEV=""
 
-echo "[SUCCESS] EFI System Partition image created: ${ESP_IMG}"
+echo "[SUCCESS] EFI System Partition image created: ${OUT_IMG}"
+echo "[INFO] Contains: /EFI/BOOT/BOOTAA64.EFI (standalone GRUB + embedded bootstrap)."
+echo "[INFO] Ensure rootfs filesystem label is '${ROOT_LABEL}' and it provides /boot/grub/grub.cfg."

--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -565,10 +565,6 @@ sed -i 's/search --no-floppy --fs-uuid --set=root .*/search --no-floppy --label 
 # conflicts with our 'root=LABEL=system' argument.
 sed -i 's/root=\/dev\/[^ ]* //g' /boot/grub/grub.cfg
 
-# 3. Legacy Compatibility
-# Create a relative symlink for bootloaders expecting the old path.
-ln -sf grub/grub.cfg /boot/grub.cfg
-
 # ==============================================================================
 # Device Tree Configuration for Debian platforms
 # ==============================================================================


### PR DESCRIPTION
This PR refactors `bootloader/build-efi-esp.sh` to generate the EFI System Partition artifact as a deterministic, self-contained ARM64 fallback loader (`EFI/BOOT/BOOTAA64.EFI`) using `grub-mkstandalone`. The resulting ESP image (`efi.bin`) no longer depends on `grub-install` installation layout behavior and is better suited for CI/Docker environments.

Key changes
- Replace `grub-install` with `grub-mkstandalone -O arm64-efi` to produce a standalone `BOOTAA64.EFI` (UEFI removable path).
- Embed a minimal bootstrap GRUB config into the EFI binary to:
  - `search --label system --set=root`
  - chainload `($root)/boot/grub/grub.cfg`
  This keeps the rootfs GRUB configuration as the single source of truth while making the ESP a minimal carrier.
- Harden the script for production builds:
  - strict named-argument parsing and validation (`--sector-size`, `--esp-size-mb`, `--root-label`, `--out`, `--no-install`)
  - mktemp-based staging and trap-based cleanup to avoid leaked mounts/loop devices
  - explicit validation of the arm64-efi GRUB platform module directory with actionable errors (common container failure mode)
  - FAT32 sizing safeguard for 4K-sector ESP builds
- Improve cross-distro compatibility by removing the optional `efi_uga` module from the embedded module list (some GRUB builds don’t ship `efi_uga.mod`).
- Rename default output image from `efiesp.bin` to `efi.bin` and update all help text accordingly.
- build-rootfs: Remove legacy /boot/grub.cfg symlink to enforce a single standard path
rootfs/scripts/build-rootfs.sh

Result
`build-efi-esp.sh` now produces an ESP filesystem image containing:
- `EFI/BOOT/BOOTAA64.EFI` (standalone GRUB + embedded bootstrap)

Notes / requirements
- Boot requires the root filesystem to be labeled `system` (or the label passed via `--root-label`) and to provide `/boot/grub/grub.cfg`.
- For container builds, ensure the image includes the ARM64 GRUB platform files (e.g. `/usr/lib/grub/arm64-efi`, typically from `grub-efi-arm64-bin` for the target arch). Use `--no-install` when dependencies are preinstalled.