### PR TITLE
scripts: build_kernel.sh/build-kernel-deb.sh: support deploying .dtbo files

### DIFF
--- a/kernel/scripts/build-kernel-deb.sh
+++ b/kernel/scripts/build-kernel-deb.sh
@@ -80,6 +80,7 @@ IMAGE="$OUT_DIR/Image"
 CONFIG="$OUT_DIR/.config"
 MODULES="$OUT_DIR/modules/lib/modules/$BASE_KERNEL_VERSION"
 DTB="$OUT_DIR/*.dtb"
+DTBO="$OUT_DIR/*.dtbo"
 
 # Print required kernel products
 echo "============================================================"
@@ -137,6 +138,13 @@ cp -rap "$MODULES" "$DEB_DIR/lib/modules/"
 
 echo "Copying device tree blobs to /boot/dtbs..."
 cp "$OUT_DIR"/*.dtb "$DEB_DIR/lib/firmware/$BASE_KERNEL_VERSION/device-tree/"
+
+if [ -n "$(ls -A $DTBO 2>/dev/null)" ]; then
+    echo "Copying device tree blobs overlay to /boot/dtbos..."
+    cp "$OUT_DIR"/*.dtbo "$DEB_DIR/lib/firmware/$BASE_KERNEL_VERSION/device-tree/"
+else
+    echo "No .dtbo files found, skipping DTB overlay copy."
+fi
 
 echo "Creating control file..."
 # Create control file

--- a/kernel/scripts/build_kernel.sh
+++ b/kernel/scripts/build_kernel.sh
@@ -34,5 +34,5 @@ make ARCH=arm64 modules
 # Deploy kernel modules to out/
 make ARCH=arm64 modules_install INSTALL_MOD_PATH=$BUILD_TOP/out/modules INSTALL_MOD_STRIP=1
 
-# Deploy ALL device tree blobs (*.dtb) to out/ (recursively)
-find "$kpath/dts" -type f -name '*.dtb' -print0 | xargs -0 -I{} cp "{}" "$BUILD_TOP/out/"
+# Deploy all Qualcomm platform device tree blobs (*.dtb) and device tree blobs overlay (*.dtbo) to out/ (recursively)
+find "$kpath/dts/qcom" -type f \( -name '*.dtb' -o -name '*.dtbo' \) -print0 | xargs -0 -I{} cp "{}" "$BUILD_TOP/out/"


### PR DESCRIPTION
Currently, the build script only deploys Device Tree Blobs (*.dtb) to the output directory and kernel deb. In order to support Device Tree Overlays (e.g., for FIT DTB images or dynamic DTB loading), the generated *.dtbo files will also be deployed.

## Key changes
* **`kernel/scripts/build_kernel.sh`**: 
  * Updated the `find` command to recursively locate and copy both `*.dtb` and `*.dtbo` files from the kernel dts directory to the `$BUILD_TOP/out/` directory.
* **`kernel/scripts/build-kernel-deb.sh`**: 
  * If `.dtbo` files are present, they are copied into the Debian package at `/lib/firmware/$BASE_KERNEL_VERSION/device-tree/` alongside the standard `.dtb` files.
  * If no `.dtbo` files are found, it safely skips the copy operation to prevent build errors.