### PR TITLE
build-rootfs: add zstd to required packages list

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -210,6 +210,7 @@ _seed_to_debootstrap_include() {
         apt
         grub-common
         grub2-common
+        zstd
     )
 
     for p in "${required_pkgs[@]}"; do


### PR DESCRIPTION
zstd was missing from the rootfs package list, causing update-initramfs to fall back to gzip compression when generating initrd images, with the warning: "No zstd in /usr/bin:/sbin:/bin, using gzip".

Add zstd into the required packages list to fix this warning, and zstd offers better compression ratio and faster decompression speed.

Issue logs:
root@qcom:/home/qcom# dpkg -i linux-kernel-6.19.0-gb133a759865e-dirty-arm64.deb
Selecting previously unselected package linux-kernel-6.19.0-gb133a759865e-dirty.
(Reading database ... 93094 files and directories currently installed.)
Preparing to unpack linux-kernel-6.19.0-gb133a759865e-dirty-arm64.deb ...
Starting cleanup of existing kernel products matching version 6.19.0-gb133a759865e-dirty...
Cleanup complete. Proceeding with installation.
Unpacking linux-kernel-6.19.0-gb133a759865e-dirty (6.19.0-gb133a759865e-dirty) ...
Setting up linux-kernel-6.19.0-gb133a759865e-dirty (6.19.0-gb133a759865e-dirty) ...
Starting post-installation procedure for Linux kernel package version 6.19.0-gb133a759865e-dirty...
Updating initramfs and generating initrd image...
update-initramfs: Generating /boot/initrd.img-6.19.0-gb133a759865e-dirty
**W: No zstd in /usr/bin:/sbin:/bin, using gzip**
Successfully updated initramfs.
Updating GRUB bootloader...
Sourcing file `/etc/default/grub'
Sourcing file `/etc/default/grub.d/kdump-tools.cfg'
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-6.19.0-rc6
Found initrd image: /boot/initrd.img-6.19.0-rc6
Found linux image: /boot/vmlinuz-6.19.0-gb133a759865e-dirty
Found initrd image: /boot/initrd.img-6.19.0-gb133a759865e-dirty
Adding boot menu entry for UEFI Firmware Settings ...
done
Successfully updated GRUB.
Linux kernel package version 6.19.0-gb133a759865e-dirty installed successfully.
To apply the new kernel, a system reboot is required.

