### PR TITLE
Update qcom-preflight-checks.yml

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,6 +1,6 @@
 name: Qualcomm Preflight Checks
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - latest
@@ -17,14 +17,14 @@ permissions:
  security-events: write
 
 jobs:
-  qcom-preflight-checks:
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/qcom-preflight-checks-reusable-workflow.yml@v1.1.4
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
     with:
-        # ✅ Preflight Checkers
-        repolinter: true                   # default: true
-        semgrep: true                      # default: true
-        copyright-license-detector: true   # default: true
-        pr-check-emails: true              # default: true
-        dependency-review: true            # default: true
-    secrets:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+      enable-armor-checkers: false


### PR DESCRIPTION
Running untrusted code on the pull_request_target trigger may lead to security vulnerabilities. These vulnerabilities include cache poisoning and granting unintended access to write privileges or secrets.

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target

We should update all usage of pull_request_target in all workflow files and also update qualcomm-preflight-check to the latest.