### PR TITLE
build-dtb-image: recurse vendor subdirs and prefer Debian standard DTB path with usrmerge fallback; build-rootfs: bypass zz-update-grub systemd guard in chroot

### DIFF
--- a/kernel/scripts/build-dtb-image.sh
+++ b/kernel/scripts/build-dtb-image.sh
@@ -18,12 +18,13 @@
 #     (A) Kernel .deb mode (recommended / upstream-friendly)
 #         - Provide a Debian kernel package (.deb) as input.
 #         - The script extracts the .deb via `dpkg-deb -R` into a temp directory.
-#         - DTBs are expected to be present under:
-#             $DEB_DIR/usr/lib/firmware/$BASE_KERNEL_VERSION/device-tree  (usrmerge layout)
-#             $DEB_DIR/lib/firmware/$BASE_KERNEL_VERSION/device-tree       (legacy layout)
-#           where $BASE_KERNEL_VERSION can be anything.
-#         - The script assumes there is exactly ONE device-tree directory across
-#           both search paths.
+#         - DTBs are located by probing the following paths in order:
+#             1. $DEB_DIR/usr/lib/linux-image-*/   (Debian standard — direct, no symlink)
+#             2. $DEB_DIR/usr/lib/firmware/*/device-tree  (Ubuntu compat, usrmerge layout)
+#             3. $DEB_DIR/lib/firmware/*/device-tree      (Ubuntu compat, legacy layout)
+#           Probing the Debian standard path first ensures correct operation on
+#           both Debian and Ubuntu regardless of whether the compat symlink exists.
+#         - The script assumes there is exactly ONE matching directory.
 #
 #     (B) DTB source directory mode (dev/kernel-tree mode)
 #         - Provide the DTB source directory directly (e.g. a kernel build tree):
@@ -171,10 +172,11 @@ usage() {
     cat <<EOF
 Usage: $0 (--kernel-deb <kernel.deb> | --dtb-src <path>) --manifest <file> [--size <MB>] [--out <file>]
 
-  --kernel-deb, -kernel-deb  Path to Debian kernel package (.deb). DTBs read from:
-                             <extract>/usr/lib/firmware/*/device-tree  (usrmerge layout)
-                             <extract>/lib/firmware/*/device-tree       (legacy layout)
-                             Exactly one device-tree directory must be found.
+  --kernel-deb, -kernel-deb  Path to Debian kernel package (.deb). DTBs located by probing:
+                             1. <extract>/usr/lib/linux-image-*/        (Debian standard)
+                             2. <extract>/usr/lib/firmware/*/device-tree (Ubuntu, usrmerge)
+                             3. <extract>/lib/firmware/*/device-tree     (Ubuntu, legacy)
+                             Exactly one directory must be found across all search paths.
 
   --dtb-src,   -dtb-src      Path to DTB source directory
                              (e.g. arch/arm64/boot/dts/qcom)
@@ -364,12 +366,19 @@ if [[ -n "${KERNEL_DEB}" ]]; then
     echo "[INFO] Extracting kernel .deb to: ${DEB_DIR}"
     dpkg-deb -R "${KERNEL_DEB}" "${DEB_DIR}"
 
-    # Locate exactly one device-tree directory.
-    # Modern packages (usrmerge / pkg-linux-qcom) install the compat symlink under
-    # usr/lib/firmware/<KVER>/device-tree; legacy packages used lib/firmware/.
-    # Check usr/lib/firmware/ first; fall back to lib/firmware/.
+    # Locate the DTB directory from the extracted .deb.
+    # Probe in order (most to least preferred):
+    #   1. usr/lib/linux-image-*/  — Debian standard install location (direct, no symlink).
+    #                                Works on both Debian and Ubuntu regardless of usrmerge.
+    #   2. usr/lib/firmware/*/device-tree — Ubuntu compat symlink (usrmerge layout).
+    #   3. lib/firmware/*/device-tree     — Ubuntu compat symlink (legacy layout).
+    # Searching the Debian standard path first avoids any dependency on the Ubuntu
+    # compat symlink and is correct on pure Debian systems that never install it.
     shopt -s nullglob
-    dt_dirs=( "${DEB_DIR}/usr/lib/firmware"/*/device-tree )
+    dt_dirs=( "${DEB_DIR}/usr/lib/linux-image-"*/ )
+    if (( ${#dt_dirs[@]} == 0 )); then
+        dt_dirs=( "${DEB_DIR}/usr/lib/firmware"/*/device-tree )
+    fi
     if (( ${#dt_dirs[@]} == 0 )); then
         dt_dirs=( "${DEB_DIR}/lib/firmware"/*/device-tree )
     fi
@@ -377,6 +386,7 @@ if [[ -n "${KERNEL_DEB}" ]]; then
 
     if (( ${#dt_dirs[@]} == 0 )); then
         echo "[ERROR] No DTB directory found under:" >&2
+        echo "        '${DEB_DIR}/usr/lib/linux-image-*/'" >&2
         echo "        '${DEB_DIR}/usr/lib/firmware/*/device-tree'" >&2
         echo "        '${DEB_DIR}/lib/firmware/*/device-tree'" >&2
         exit 1
@@ -530,7 +540,7 @@ else
     if (( dtb_count == 0 )); then
         echo "[ERROR] No DTB files found under ${DTB_SRC}" >&2
         echo "        Verify the kernel package was built with DTB support" >&2
-        echo "        and that usr/lib/firmware/*/device-tree resolves correctly." >&2
+        echo "        and that usr/lib/linux-image-*/ is present in the package." >&2
         exit 1
     fi
     echo "[INFO] Staged ${dtb_count} DTB file(s) to ${DTB_STAGE}"

--- a/kernel/scripts/build-dtb-image.sh
+++ b/kernel/scripts/build-dtb-image.sh
@@ -19,10 +19,11 @@
 #         - Provide a Debian kernel package (.deb) as input.
 #         - The script extracts the .deb via `dpkg-deb -R` into a temp directory.
 #         - DTBs are expected to be present under:
-#             $DEB_DIR/lib/firmware/$BASE_KERNEL_VERSION/device-tree
+#             $DEB_DIR/usr/lib/firmware/$BASE_KERNEL_VERSION/device-tree  (usrmerge layout)
+#             $DEB_DIR/lib/firmware/$BASE_KERNEL_VERSION/device-tree       (legacy layout)
 #           where $BASE_KERNEL_VERSION can be anything.
-#         - The script assumes there is exactly ONE:
-#             $DEB_DIR/lib/firmware/*/device-tree
+#         - The script assumes there is exactly ONE device-tree directory across
+#           both search paths.
 #
 #     (B) DTB source directory mode (dev/kernel-tree mode)
 #         - Provide the DTB source directory directly (e.g. a kernel build tree):
@@ -171,7 +172,9 @@ usage() {
 Usage: $0 (--kernel-deb <kernel.deb> | --dtb-src <path>) --manifest <file> [--size <MB>] [--out <file>]
 
   --kernel-deb, -kernel-deb  Path to Debian kernel package (.deb). DTBs read from:
-                             <extract>/lib/firmware/*/device-tree  (must be exactly one)
+                             <extract>/usr/lib/firmware/*/device-tree  (usrmerge layout)
+                             <extract>/lib/firmware/*/device-tree       (legacy layout)
+                             Exactly one device-tree directory must be found.
 
   --dtb-src,   -dtb-src      Path to DTB source directory
                              (e.g. arch/arm64/boot/dts/qcom)
@@ -361,13 +364,21 @@ if [[ -n "${KERNEL_DEB}" ]]; then
     echo "[INFO] Extracting kernel .deb to: ${DEB_DIR}"
     dpkg-deb -R "${KERNEL_DEB}" "${DEB_DIR}"
 
-    # Locate exactly one device-tree directory under lib/firmware/*/device-tree
+    # Locate exactly one device-tree directory.
+    # Modern packages (usrmerge / pkg-linux-qcom) install the compat symlink under
+    # usr/lib/firmware/<KVER>/device-tree; legacy packages used lib/firmware/.
+    # Check usr/lib/firmware/ first; fall back to lib/firmware/.
     shopt -s nullglob
-    dt_dirs=( "${DEB_DIR}/lib/firmware"/*/device-tree )
+    dt_dirs=( "${DEB_DIR}/usr/lib/firmware"/*/device-tree )
+    if (( ${#dt_dirs[@]} == 0 )); then
+        dt_dirs=( "${DEB_DIR}/lib/firmware"/*/device-tree )
+    fi
     shopt -u nullglob
 
     if (( ${#dt_dirs[@]} == 0 )); then
-        echo "[ERROR] No DTB directory found at '${DEB_DIR}/lib/firmware/*/device-tree'." >&2
+        echo "[ERROR] No DTB directory found under:" >&2
+        echo "        '${DEB_DIR}/usr/lib/firmware/*/device-tree'" >&2
+        echo "        '${DEB_DIR}/lib/firmware/*/device-tree'" >&2
         exit 1
     fi
     if (( ${#dt_dirs[@]} > 1 )); then
@@ -519,7 +530,7 @@ else
     if (( dtb_count == 0 )); then
         echo "[ERROR] No DTB files found under ${DTB_SRC}" >&2
         echo "        Verify the kernel package was built with DTB support" >&2
-        echo "        and that lib/firmware/*/device-tree resolves correctly." >&2
+        echo "        and that usr/lib/firmware/*/device-tree resolves correctly." >&2
         exit 1
     fi
     echo "[INFO] Staged ${dtb_count} DTB file(s) to ${DTB_STAGE}"

--- a/kernel/scripts/build-dtb-image.sh
+++ b/kernel/scripts/build-dtb-image.sh
@@ -504,9 +504,27 @@ else
     DTB_STAGE="${FIT_STAGE}/arch/arm64/boot/dts/qcom"
     mkdir -p "${DTB_STAGE}"
 
-    # Copy DTBs from the resolved DTB source directory
+    # Copy DTBs from the resolved DTB source directory.
+    # DTBs may be nested under vendor subdirectories (e.g. qcom/), so use
+    # find -L (follow symlinks) rather than a flat glob to collect them all
+    # into the staging dir flat — the ITS file references them by basename
+    # under arch/arm64/boot/dts/qcom/.
     echo "[INFO] Copying DTBs from ${DTB_SRC} ..."
-    cp -rap "${DTB_SRC}"/*.dtb* "${DTB_STAGE}/"
+    dtb_count=0
+    while IFS= read -r dtb; do
+        cp -p "${dtb}" "${DTB_STAGE}/"
+        (( dtb_count++ )) || true
+    done < <(find -L "${DTB_SRC}" \( -name '*.dtb' -o -name '*.dtbo' \) -type f)
+
+    if (( dtb_count == 0 )); then
+        echo "[ERROR] No DTB files found under ${DTB_SRC}" >&2
+        echo "        Verify the kernel package was built with DTB support" >&2
+        echo "        and that lib/firmware/*/device-tree resolves correctly." >&2
+        exit 1
+    fi
+    echo "[INFO] Staged ${dtb_count} DTB file(s) to ${DTB_STAGE}"
+    echo "[INFO] Staged DTBs:"
+    ls "${DTB_STAGE}"/*.dtb 2>/dev/null | xargs -n1 basename | sort | sed 's/^/        /'
 
     # -----------------------------------------------------------------------
     # Step 4. Compile qcom-metadata.dts → qcom-metadata.dtb

--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -551,6 +551,10 @@ echo '[CHROOT] Installing custom firmware and kernel...'
 $CMD_FW_INSTALL
 yes \"\" | dpkg -i /$(basename "$KERNEL_DEB")
 
+# Run update-grub explicitly: the zz-update-grub hook skips it in a chroot
+# because systemd is not running (/run/systemd/system absent).
+update-grub
+
 adduser --disabled-password --gecos '' qcom
 echo 'qcom:qcom' | chpasswd
 usermod -aG sudo qcom


### PR DESCRIPTION
## Problem

Three independent failures surface when the CI pipeline switches from the
legacy `build-kernel-deb.sh`-generated package to the `pkg-linux-qcom`
Debian package (`linux-image-<KVER>-qcom`) built via `debian/` metadata.

### 1 — `build-dtb-image.sh`: flat glob misses DTBs in vendor subdirectories

The FIT image build path collected DTBs using a flat glob:

```bash
cp -rap "${DTB_SRC}"/*.dtb* "${DTB_STAGE}/"
```

This assumes all DTB files reside directly in `DTB_SRC`. In practice,
DTBs are always installed one level deeper under a vendor subdirectory:

```
lib/firmware/<KVER>/device-tree/
  qcom/
    x1e80100-qcp.dtb
    sc8280xp-lenovo-thinkpad-x13s.dtb
    ...
```

When `--kernel-deb` is used, `DTB_SRC` resolves to the `device-tree`
directory (a symlink to the Debian-standard install path
`usr/lib/linux-image-<KVER>/`). The glob expands to nothing and the
build fails:

```
[INFO] Copying DTBs from /tmp/kernel-deb-ILIZ66/lib/firmware/7.0.0-rc5/device-tree ...
cp: cannot stat '/tmp/kernel-deb-ILIZ66/lib/firmware/7.0.0-rc5/device-tree/*.dtb*': No such file or directory
Error: Process completed with exit code 1.
```

### 2 — `build-dtb-image.sh`: device-tree directory not found in usrmerge packages

`pkg-linux-qcom` now installs the `device-tree` compat symlink under
`usr/lib/firmware/<KVER>/device-tree` (required to fix broken symlink
resolution on usrmerge systems where `/lib → usr/lib`). The previous
discovery glob only searched `lib/firmware/*/device-tree`:

```bash
dt_dirs=( "${DEB_DIR}/lib/firmware"/*/device-tree )
```

This expands to nothing for packages built with the updated `debian/rules`,
causing `--kernel-deb` mode to fail immediately after extraction.

### 3 — `build-rootfs.sh`: `/boot/grub/grub.cfg` never created in chroot

The `pkg-linux-qcom` postinst correctly follows the Debian standard of
delegating bootloader updates to `/etc/kernel/postinst.d` hooks. The
`zz-update-grub` hook (from `grub-common`) guards its `update-grub` call
with a systemd check:

```bash
if [ -d /run/systemd/system ]; then update-grub || true; fi
```

In a chroot, systemd is not running, so `/run/systemd/system` does not
exist and `update-grub` is silently skipped — `/boot/grub/grub.cfg` is
never created. The subsequent `sed`-based GRUB cleanup then fails:

```
sed: can't read /boot/grub/grub.cfg: No such file or directory
Error: Process completed with exit code 1.
```

The `build-kernel-deb.sh`-generated package called `update-grub`
unconditionally in its postinst, so it was unaffected.

---

## Fix

### 1 — `build-dtb-image.sh`: recursive DTB collection

Replace the flat glob with `find -L`, which follows symlinks and recurses
into all vendor subdirectories, copying every `*.dtb` and `*.dtbo` file
flat into the `mkimage` staging directory (`arch/arm64/boot/dts/qcom/`),
as the ITS file expects:

```bash
while IFS= read -r dtb; do
    cp -p "${dtb}" "${DTB_STAGE}/"
done < <(find -L "${DTB_SRC}" \( -name '*.dtb' -o -name '*.dtbo' \) -type f)
```

`find -L` follows symlinks transparently, so this works correctly whether
`device-tree` is a real directory or a relative directory symlink (as
introduced in [pkg-linux-qcom#11](https://github.com/qualcomm-linux/pkg-linux-qcom/pull/11)).

A post-copy count check and sorted DTB listing are also added so that an
empty or misconfigured DTB source is caught early with a clear diagnostic
rather than a cryptic `mkimage` `FATAL ERROR`:

```
[INFO] Staged 47 DTB file(s) to arch/arm64/boot/dts/qcom
[INFO] Staged DTBs:
        qcm6490-idp.dtb
        sc8280xp-lenovo-thinkpad-x13s.dtb
        ...
```

### 2 — `build-dtb-image.sh`: Debian-standard-first DTB discovery

Probe paths in order, falling back only if the preferred path is absent:

```bash
# 1. Debian standard install location (direct, no symlink — works on Debian and Ubuntu)
dt_dirs=( "${DEB_DIR}/usr/lib/linux-image-"*/ )
# 2. Ubuntu compat symlink (usrmerge layout)
if (( ${#dt_dirs[@]} == 0 )); then
    dt_dirs=( "${DEB_DIR}/usr/lib/firmware"/*/device-tree )
fi
# 3. Ubuntu compat symlink (legacy layout)
if (( ${#dt_dirs[@]} == 0 )); then
    dt_dirs=( "${DEB_DIR}/lib/firmware"/*/device-tree )
fi
```

Probing the Debian standard path first avoids any dependency on the Ubuntu
compat symlink and works correctly on pure Debian systems that never install
it. The fallback chain is fully backward compatible: legacy packages (built
by `build-kernel-deb.sh`) only populate `lib/firmware/`, so the script
falls through steps 1 and 2 and resolves via step 3 as before.

### 3 — `build-rootfs.sh`: explicit `update-grub` in chroot

Call `update-grub` explicitly in the chroot immediately after kernel
installation, bypassing the systemd guard. `build-rootfs.sh` owns the
chroot environment and is the right place to ensure `grub.cfg` is
generated — the kernel package postinst is intentionally unchanged:

```bash
yes "" | dpkg -i /linux-image-<KVER>-qcom.deb

# Run update-grub explicitly: the zz-update-grub hook skips it in a chroot
# because systemd is not running (/run/systemd/system absent).
update-grub
```

---

## Changes

- `kernel/scripts/build-dtb-image.sh`: replace `cp -rap *.dtb*` flat glob
  with recursive `find -L` + `cp` loop in FIT image mode; add staged DTB
  count check and listing; probe `usr/lib/linux-image-*/` first (Debian
  standard), then `usr/lib/firmware/*/device-tree` (usrmerge), then
  `lib/firmware/*/device-tree` (legacy) for full backward compatibility
- `rootfs/scripts/build-rootfs.sh`: call `update-grub` explicitly after
  kernel `.deb` installation to ensure `/boot/grub/grub.cfg` is generated
  in chroot environments where the `zz-update-grub` systemd guard skips it

---

## Testing

```bash
# Fix 1+2 — DTB collection (pkg-linux-qcom package, Debian standard path)
./scripts/build-dtb-image.sh \
    --fit-image \
    --kernel-deb linux-image-7.0.0-rc5-qcom_1-1_arm64.deb \
    --metadata-commit 5d24fea316a512f85acf7a4528a118ce52223530 \
    --out dtb.bin
# Previously: cp: cannot stat '.../device-tree/*.dtb*': No such file or directory
#         or: No DTB directory found at '.../lib/firmware/*/device-tree'
# Now: DTBs collected from usr/lib/linux-image-.../ and staged correctly ✓
#      Falls back to lib/firmware/ for legacy packages ✓

# Fix 3 — GRUB config generation
./build-rootfs.sh \
    --product-conf qcom-product.conf \
    --seed seed.txt \
    --kernel-package linux-image-7.0.0-rc5-qcom_1-1_arm64.deb
# Previously: sed: can't read /boot/grub/grub.cfg: No such file or directory
# Now: update-grub runs in chroot, grub.cfg generated, sed cleanup succeeds ✓
```