### PR TITLE
Switch from pull_request_target to pull_request trigger

### DIFF
--- a/.github/actions/push_to_repo/action.yml
+++ b/.github/actions/push_to_repo/action.yml
@@ -102,7 +102,7 @@ runs:
 
     - name: Checkout Staging Repo
       if: steps.check-version.outputs.do_upload == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: ${{env.REPO_NAME}}
         ref: main

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -46,6 +46,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   build-debian-package:
@@ -58,11 +59,11 @@ jobs:
 
     container:
       # This docker image is built and published by the qualcomm-linux/docker_deb_build repo CI workflow
-      image: ghcr.io/qualcomm-linux/pkg-builder:arm64-${{inputs.distro-codename}}
+      image: ghcr.io/qualcomm-linux/pkg-builder:${{inputs.distro-codename}}
       options: --privileged
       credentials:
-        username: ${{vars.DEB_PKG_BOT_CI_USERNAME}}
-        password: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
 
@@ -71,7 +72,6 @@ jobs:
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
-          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./qcom-build-utils
           fetch-depth: 1
           sparse-checkout: |
@@ -82,7 +82,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{inputs.debian-ref}}
-          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./package-repo
           fetch-depth: 0 # <- Important for the tags fetching to work
           fetch-tags: true # <- Important

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
 
       - name: Checkout qcom-build-utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
@@ -79,7 +79,7 @@ jobs:
             scripts
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{inputs.debian-ref}}
           path: ./package-repo

--- a/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml
+++ b/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
 
       - name: Checkout qcom-build-utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
@@ -83,7 +83,7 @@ jobs:
             scripts
 
       - name: Checkout Packaging Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ./package-repo
           fetch-depth: 0

--- a/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml
+++ b/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml
@@ -50,6 +50,7 @@ on:
 
 permissions:
   contents: write
+  packages: read
   pull-requests: write
 
 jobs:
@@ -63,10 +64,10 @@ jobs:
 
     container:
       # This docker image is built and published by the qualcomm-linux/docker_deb_build repo CI workflow
-      image: ghcr.io/qualcomm-linux/pkg-builder:arm64-noble
+      image: ghcr.io/qualcomm-linux/pkg-builder:noble
       credentials:
-        username: ${{ vars.DEB_PKG_BOT_CI_USERNAME }}
-        password: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
 
@@ -84,7 +85,6 @@ jobs:
       - name: Checkout Packaging Repo
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./package-repo
           fetch-depth: 0
           fetch-tags: true
@@ -231,7 +231,7 @@ jobs:
         run: |
           cd ./package-repo
 
-          gh auth login --with-token <<< "${{secrets.DEB_PKG_BOT_CI_TOKEN}}"
+          gh auth login --with-token <<< "${{secrets.GITHUB_TOKEN}}"
 
           PR_TITLE="Promotion to ${{env.NEW_DEBIAN_VERSION}} (Artifactory tag: ${{inputs.new-tag}})"
 

--- a/.github/workflows/qcom-promote-upstream-reusable-workflow.yml
+++ b/.github/workflows/qcom-promote-upstream-reusable-workflow.yml
@@ -31,13 +31,17 @@ on:
         type: string
         required: true
 
+    secrets:
+      PAT:
+        required: false
+
 permissions:
   contents: write
+  packages: read
+  pull-requests: write
 
 env:
   NORMALIZED_VERSION: ""
-  DISTRIBUTION: noble
-
   UPSTREAM_TAG_ALREADY_EXISTS: false
 
 jobs:
@@ -50,11 +54,11 @@ jobs:
         shell: bash
 
     container:
-      # This docker image is built and published by the qualcomm-linux/docker_deb_build repo CI workflow
-      image: ghcr.io/qualcomm-linux/pkg-builder:arm64-noble
+      # This docker image is built and published by the qualcomm-linux/docker-pkg-build repo CI workflow
+      image: ghcr.io/qualcomm-linux/pkg-builder:noble
       credentials:
-        username: ${{ vars.DEB_PKG_BOT_CI_USERNAME }}
-        password: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
 
@@ -73,7 +77,6 @@ jobs:
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
-          #token: Not needed for public repo
           path: ./qcom-build-utils
           fetch-depth: 1
           sparse-checkout: |
@@ -84,14 +87,17 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
+          token: ${{secrets.PAT}}
           path: ./package-repo
           fetch-depth: 0
 
-      - name: Show branches/tags and checkout debian/upstream latest
-        run: |
-          cd ./package-repo
+      - name: Authenticate with GitHub
+        run : |
+          gh auth login --with-token <<< "${{secrets.PAT}}"
 
+      - name: Show branches/tags and checkout debian/upstream latest
+        working-directory: ./package-repo
+        run: |
           git branch
           git tag
           git checkout ${{inputs.debian-branch}}
@@ -102,20 +108,17 @@ jobs:
             git checkout - # Then revert back to the inputs.debian-branch branch as we will need to have it checked out for gbp later
           fi
 
-
       - name: Make sure the upstream tag is not already part of the repo
+        working-directory: ./package-repo
         run: |
-          cd ./package-repo
-
           if (git tag --list | grep "${{inputs.upstream-tag}}"); then
             echo "❌ The supplied upstream tag is wrong as it pertains to this repo already."
             exit 1
           fi
 
       - name: Validate the upstream tag promotion state
+        working-directory: ./package-repo
         run: |
-          cd ./package-repo
-
           # Check if the upstream/<normalized_version> tag does not already exists
           if ! git tag --list | grep "upstream/${{env.NORMALIZED_VERSION}}"; then
             echo "✅ The upstream tag '${{inputs.upstream-tag}}' has not been promoted yet. Continuing."
@@ -138,7 +141,6 @@ jobs:
           echo "ℹ️ This is likely a second attempt to promote the same upstream tag, where the first attempt already added the upstream tag in the upstram branch"
 
           # Check if there is a PR open for this already
-          gh auth login --with-token <<< "${{secrets.DEB_PKG_BOT_CI_TOKEN}}"
           PRS=$(gh pr list --head "debian/pr/${{env.NORMALIZED_VERSION}}-1" --state open --json number --jq '.[].number')
           if [ -n "$PRS" ]; then
             echo "❌ An open PR already exists for this promotion attempt: $PRS"
@@ -163,20 +165,43 @@ jobs:
           fi
 
       - name: Add Upstream Link As A Remote And Fetch Tags
+        working-directory: ./package-repo
         run: |
-          cd ./package-repo
-          git remote add upstream-source https://x-access-token:${{secrets.DEB_PKG_BOT_CI_TOKEN}}@github.com/${{inputs.upstream-repo}}.git
-          git fetch upstream-source "+refs/tags/*:refs/tags/*"
+          if [ -n "${{secrets.PAT}}" ]; then
+            echo "ℹ️ Adding upstream remote with token authentication. This is because the upstream repository may be private and require authentication to fetch tags."
+            REPO_URL=https://x-access-token:${{secrets.PAT}}@github.com/${{inputs.upstream-repo}}.git
+          else
+            echo "ℹ️ Adding upstream remote without token authentication, repo is assumed to be public"
+            REPO_URL=https://github.com/${{inputs.upstream-repo}}.git
+          fi
+
+          git remote add upstream-source $REPO_URL
+
+          echo "ℹ️ Fetching tags from upstream repository using token authentication."
+
+          # Override the global extraheader set by actions/checkout (GITHUB_TOKEN) which would otherwise
+          # take precedence over the credentials embedded in the URL and prevent access to external repos.
+          if ! git fetch upstream-source "+refs/tags/*:refs/tags/*"; then
+            echo "❌ Failed to fetch tags from '${{inputs.upstream-repo}}'."
+
+            if [ -n "${{secrets.PAT}}" ]; then
+              echo "❌ Ensure that the PAT token has the  permission on the repository."
+              echo "❌ For more information about this token, see the README.md in qcom-build-utils repo."
+            else
+              echo "❌ Make sure the upstream repository is public or if it is private that the PAT token is set and has the necessary permissions."
+            fi
+
+            exit 1
+          fi
 
       - name: Ensure the tag exists in the upstream repo
+        working-directory: ./package-repo
         run: |
-          cd ./package-repo
-
           if ! git rev-parse --verify "refs/tags/${{inputs.upstream-tag}}" >/dev/null 2>&1; then
             echo "❌ The specified upstream tag '${{inputs.upstream-tag}}' does not exist in the upstream repository."
             exit 1
           fi
-          
+
       - name: Pre-populate the upstream/latest branch if first promotion
         run: |
           cd ./package-repo
@@ -193,9 +218,8 @@ jobs:
           fi
 
       - name: Merge upstream tag into packaging branch
+        working-directory: ./package-repo
         run: |
-          cd ./package-repo
-
           git config user.name "${{vars.DEB_PKG_BOT_CI_NAME}}"
           git config user.email "${{vars.DEB_PKG_BOT_CI_EMAIL}}"
 
@@ -206,9 +230,8 @@ jobs:
           ../qcom-build-utils/scripts/merge_debian_packaging_upstream ${{inputs.upstream-tag}}
 
       - name: Promote Changelog
+        working-directory: ./package-repo
         run: |
-          cd ./package-repo
-
           export DEBFULLNAME="${{vars.DEB_PKG_BOT_CI_NAME}}"
           export DEBEMAIL="${{vars.DEB_PKG_BOT_CI_EMAIL}}"
 
@@ -221,9 +244,8 @@ jobs:
           git commit -a -s -m "Update changelog version to ${{env.NORMALIZED_VERSION}}-1 and UNRELEASED suite"
 
       - name: Push Upstream/latest and debian PR Branch
+        working-directory: ./package-repo
         run: |
-          cd ./package-repo
-
           if [ "${{env.UPSTREAM_TAG_ALREADY_EXISTS}}" = "false" ]; then
               # This is the happy path where no previous promotion attempt was detected
 
@@ -239,11 +261,8 @@ jobs:
           git push origin debian/pr/${{env.NORMALIZED_VERSION}}-1
 
       - name: Open Promotion PR
+        working-directory: ./package-repo
         run: |
-          cd ./package-repo
-
-          gh auth login --with-token <<< "${{secrets.DEB_PKG_BOT_CI_TOKEN}}"
-
           ../qcom-build-utils/scripts/create_promotion_pr.py \
             --base-branch "${{inputs.debian-branch}}" \
             --upstream-tag "${{inputs.upstream-tag}}" \

--- a/.github/workflows/qcom-promote-upstream-reusable-workflow.yml
+++ b/.github/workflows/qcom-promote-upstream-reusable-workflow.yml
@@ -73,7 +73,7 @@ jobs:
           echo "ℹ️ Normalized version : $NORMALIZED_VERSION"
 
       - name: Checkout qcom-build-utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
@@ -85,7 +85,7 @@ jobs:
 
       # Fetch all history for all tags and branches
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{secrets.PAT}}
           path: ./package-repo

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -32,6 +32,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   pkg-release:
@@ -47,11 +48,11 @@ jobs:
 
     container:
       # This docker image is built and published by the qualcomm-linux/docker_deb_build repo CI workflow
-      image: ghcr.io/qualcomm-linux/pkg-builder:arm64-${{inputs.distro-codename}}
+      image: ghcr.io/qualcomm-linux/pkg-builder:${{inputs.distro-codename}}
       options: --privileged
       credentials:
-        username: ${{vars.DEB_PKG_BOT_CI_USERNAME}}
-        password: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
 
@@ -69,7 +70,6 @@ jobs:
       - name: Checkout Packaging Repo
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./package-repo
           fetch-depth: 0
           fetch-tags: true
@@ -323,7 +323,7 @@ jobs:
       - name: Notify qcom-distro-images of new release via repository dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           repository: qualcomm-linux/qcom-distro-images
           event-type: pkg-repo-release
           client-payload: >-

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -328,7 +328,7 @@ jobs:
       - name: Notify qcom-distro-images of new release via repository dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.PAT}}
           repository: qualcomm-linux/qcom-distro-images
           event-type: pkg-repo-release
           client-payload: >-

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -281,7 +281,7 @@ jobs:
           sed -i 's/:/_/g' *.build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-artifacts
           path: build/
@@ -291,7 +291,7 @@ jobs:
     runs-on: 'lecore-prd-u2404-arm64-xlrg-od-ephem'
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts
           path: build/

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -30,6 +30,11 @@ on:
         type: boolean
         default: true
 
+    secrets:
+      PAT:
+        description: Personal Access Token with repo and package permissions to the packaging repository. This is needed to push the changelog commit and tag to the packaging repository.
+        required: false
+
 permissions:
   contents: read
   packages: read
@@ -70,6 +75,7 @@ jobs:
       - name: Checkout Packaging Repo
         uses: actions/checkout@v5
         with:
+          token: ${{secrets.PAT}}
           path: ./package-repo
           fetch-depth: 0
           fetch-tags: true
@@ -117,7 +123,6 @@ jobs:
 
           git log --graph --oneline -n 10 --color=always
 
-      #TODO pkg_repo_branch needs to be dynamic based on the branch used to call the workflow
       - name: Create provenance file
         run: |
           mkdir build

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
 
       - name: Checkout qcom-build-utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
@@ -68,7 +68,7 @@ jobs:
             scripts
 
       - name: Checkout Packaging Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ./package-repo
           fetch-depth: 0

--- a/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml
+++ b/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml
@@ -41,6 +41,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 env:
   # For ABI checker
@@ -60,11 +61,11 @@ jobs:
 
     container:
       # This docker image is built and published by the qualcomm-linux/docker_deb_build repo CI workflow
-      image: ghcr.io/qualcomm-linux/pkg-builder:arm64-${{inputs.distro-codename}}
+      image: ghcr.io/qualcomm-linux/pkg-builder:${{inputs.distro-codename}}
       options: --privileged
       credentials:
-        username: ${{vars.DEB_PKG_BOT_CI_USERNAME}}
-        password: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
 
@@ -84,7 +85,6 @@ jobs:
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
-          token: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
           path: ./qcom-build-utils
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml
+++ b/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml
@@ -81,7 +81,7 @@ jobs:
 
 
       - name: Checkout qcom-build-utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: qualcomm-linux/qcom-build-utils
           ref: ${{inputs.qcom-build-utils-ref}}
@@ -92,7 +92,7 @@ jobs:
             scripts
 
       - name: Checkout Packaging Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{inputs.pkg-repo}}
           clean: false
@@ -102,7 +102,7 @@ jobs:
           fetch-tags: true
 
       - name: Checkout Upstream PR Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{inputs.upstream-repo}}
           ref: ${{inputs.upstream-repo-ref}}

--- a/docs/actions/build_container.md
+++ b/docs/actions/build_container.md
@@ -102,8 +102,6 @@ This ensures published containers are functional.
   with:
     arch: arm64
     push-to-ghcr: true
-    token: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
-    username: ${{ vars.DEB_PKG_BOT_CI_USERNAME }}
 ```
 
 ## Notes

--- a/docs/package-repo-integration.md
+++ b/docs/package-repo-integration.md
@@ -111,7 +111,6 @@ If you prefer to set up a repository manually instead of using the template:
    - Require branches to be up to date
 
 3. **Configure organization secrets** (already set at org level):
-   - `DEB_PKG_BOT_CI_TOKEN` - GitHub PAT
    - `SEMGREP_APP_TOKEN` - For security scanning
 
 4. **Configure organization variables** (already set at org level):
@@ -200,11 +199,9 @@ Create the minimal workflow files that call qcom-build-utils reusable workflows.
 
 ```yaml
 name: Pre-Merge
-description: |
-  Tests that with this PR, the package builds successfully.
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ debian/qcom-next ]
 
 permissions:
@@ -220,9 +217,6 @@ jobs:
       run-abi-checker: true
       push-to-repo: false
       is-post-merge: false
-
-    secrets:
-      TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 ```
 
 #### .github/workflows/post-merge.yml
@@ -249,9 +243,6 @@ jobs:
       push-to-repo: true
       run-abi-checker: true
       is-post-merge: true
-
-    secrets:
-      TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 ```
 
 #### Step 4: Initial Commit
@@ -412,8 +403,6 @@ jobs:
       upstream-tag: ${{ github.event.inputs.upstream-tag }}
       upstream-repo: ${{ github.event.inputs.upstream-repo }}
       promote-changelog: true
-    secrets:
-      TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 ```
 
 #### Triggering Upstream Promotion
@@ -476,7 +465,7 @@ graph TB
 name: Package Build PR Check
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 
 permissions:
@@ -492,8 +481,6 @@ jobs:
       upstream-repo-ref: ${{github.head_ref}}         # PR branch
       pkg-repo: ${{vars.PKG_REPO_GITHUB_NAME}}        # Links to package repo via variable
       pr-number: ${{github.event.pull_request.number}}
-    secrets:
-      TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 ```
 
 **How the variable works**:

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -54,12 +54,6 @@ flowchart TD
 | `is-post-merge` | boolean | No | `false` | True if triggered by merge to debian/qcom-next |
 | `runner` | string | No | `lecore-prd-u2404-arm64-xlrg-od-ephem` | GitHub runner to use |
 
-### Secrets
-
-| Secret | Description |
-|--------|-------------|
-| `TOKEN` | GitHub PAT token for authentication |
-
 ### Environment Variables
 
 - `REPO_URL`: `https://qualcomm-linux.github.io/pkg-oss-staging-repo/`
@@ -88,8 +82,6 @@ jobs:
       run-abi-checker: true
       push-to-repo: false
       is-post-merge: false
-    secrets:
-      TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 ```
 
 #### Post-merge Build and Publish
@@ -104,8 +96,6 @@ jobs:
       push-to-repo: true
       run-abi-checker: true
       is-post-merge: true
-    secrets:
-      TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 ```
 
 ---
@@ -154,14 +144,13 @@ flowchart TD
 
 ### Secrets
 
-| Secret | Description |
-|--------|-------------|
-| `TOKEN` | GitHub PAT token for authentication |
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `PAT` | No | GitHub Personal Access Token for authenticating against **private** upstream repositories. Not required when the upstream repository is public. |
 
 ### Environment Variables
 
 - `NORMALIZED_VERSION`: Version with 'v' prefix removed
-- `DISTRIBUTION`: Target distribution (default: `noble`)
 
 ### Workflow Steps
 
@@ -187,8 +176,6 @@ jobs:
       upstream-tag: v2.1.0
       upstream-repo: qualcomm-linux/my-upstream-project
       promote-changelog: true
-    secrets:
-      TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 ```
 
 ### Notes
@@ -240,12 +227,6 @@ flowchart TD
 | `distro-codename` | string | No | `noble` | Distribution codename |
 | `runner` | string | No | `ubuntu-latest` | Runner to use |
 
-### Secrets
-
-| Secret | Description |
-|--------|-------------|
-| `TOKEN` | GitHub PAT token for authentication |
-
 ### Environment Variables
 
 - `REPO_URL`: APT repository URL for ABI checking
@@ -273,7 +254,7 @@ Called from upstream repository's workflow (e.g., `.github/workflows/pkg-build-p
 name: Package Build PR Check
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 
 jobs:
@@ -285,8 +266,6 @@ jobs:
       upstream-repo-ref: ${{github.head_ref}}
       pkg-repo: ${{vars.PKG_REPO_GITHUB_NAME}}
       pr-number: ${{github.event.pull_request.number}}
-    secrets:
-      TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 ```
 
 **Setup Requirements**:
@@ -473,16 +452,13 @@ jobs:
       # Input parameters
       qcom-build-utils-ref: development
       # ... other inputs
-    secrets:
-      TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
 ```
 
 ### Required Organization Secrets
 
 Package repositories need these organization secrets configured:
 
-- `DEB_PKG_BOT_CI_TOKEN` - GitHub PAT for authentication
-- `SEMGREP_APP_TOKEN` - For security scanning
+- `SEMGREP_APP_TOKEN` - For security scanning (used by qcom-preflight-checks)
 
 ### Required Organization Variables
 

--- a/docs/workflow-architecture.md
+++ b/docs/workflow-architecture.md
@@ -216,7 +216,7 @@ sequenceDiagram
 **Workflow Configuration** (in pkg-*/. github/workflows/pre-merge.yml):
 ```yaml
 on:
-  pull_request_target:
+  pull_request:
     branches: [ debian/qcom-next ]
 
 jobs:
@@ -373,14 +373,13 @@ flowchart LR
 1. **Centralization**: Workflow logic is centralized in qcom-build-utils to ensure consistency
 2. **Reusability**: Package repositories only need minimal workflow callers
 3. **Flexibility**: Workflows support various configurations through input parameters
-4. **Security**: Uses organization secrets and restricted permissions
+4. **Security**: Uses `GITHUB_TOKEN` (no long-lived PAT secrets needed for standard builds); restricted permissions per workflow
 5. **Isolation**: Each package repository is independent
 6. **Automation**: Automated building, testing, versioning, and publishing
 
 ## Security Considerations
 
-- Workflows use `pull_request_target` for secure PR builds
-- Container credentials stored as organization secrets
-- Repository access controlled via GitHub PAT tokens
+- Workflows use `on: pull_request` (not `pull_request_target`) to prevent remote code execution (RCE): PR workflows run in the context of the PR branch with restricted permissions, so repository secrets are never exposed to untrusted code from public forks
+- Container registry access uses `GITHUB_TOKEN` instead of a long-lived PAT
 - ABI checking prevents accidental API/ABI breakage
 - CodeQL and security scanning via qcom-preflight-checks


### PR DESCRIPTION
Change PR trigger pull_request_target -> pull_request
    
In order to avoid leaking secrets by remote code execution coming
from public PRs, the PR workflow trigger has been changed back to
on: pull_request. This makes that secrets outside of the GITHUB_TOKEN
cannot be used.
    
Therefore, the GITHUB_TOKEN is used all over to fetch the container.