### PR TITLE
build-rootfs: assign ip over ethernet automatically

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -642,6 +642,13 @@ echo "[INFO] Writing static /etc/resolv.conf for runtime DNS resolution..."
 rm -f "$MNT_DIR/etc/resolv.conf"
 echo -e 'nameserver 1.1.1.1\nnameserver 8.8.8.8' > "$MNT_DIR/etc/resolv.conf"
 
+mkdir -p $MNT_DIR/etc/netplan/
+cat <<EOF > "$MNT_DIR/etc/netplan/01-network-manager-all.yaml"
+network:
+    version: 2
+    renderer: NetworkManager
+EOF
+
 umount -l "$MNT_DIR"
 
 # ==============================================================================


### PR DESCRIPTION
Assign IP automatically for ethernet, required for automation test. 
ethernet is excluded by Networkmanager by default, specify it in netplan network configuration which tell networkmanager to take care of ethernet as well.