### PR TITLE
Migrate qcom-build-utils to debusine-action-backed workflows

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -10,8 +10,8 @@ description: |
   otherwise source build mode is used.
 
 inputs:
-  distro-codename:
-    description: The distribution codename to build for. Ex noble, questing, etc
+  suite:
+    description: The distribution codename or Debian suite to build for. Ex noble, questing, trixie, etc
     required: true
 
   pkg-dir:
@@ -197,7 +197,7 @@ runs:
             sbuild --no-clean-source \
                    --host=arm64 \
                    --build=${{env.BUILD_ARCH}} \
-                   --dist=${{inputs.distro-codename}} \
+                   --dist=${{inputs.suite}} \
                    $lintian_flag \
                    --build-dir "$BUILD_DIR_ABS" \
                    --build-dep-resolver=apt \
@@ -209,7 +209,7 @@ runs:
             sbuild --no-clean-source \
                    --host=arm64 \
                    --build=${{env.BUILD_ARCH}} \
-                   --dist=${{inputs.distro-codename}} \
+                   --dist=${{inputs.suite}} \
                    $lintian_flag \
                    --build-dir "$BUILD_DIR_ABS" \
                    --build-dep-resolver=apt
@@ -225,12 +225,12 @@ runs:
             --git-ignore-branch \
             --git-builder="sbuild --no-clean-source \
                                   --dpkg-source-opt="--extend-diff-ignore=^\\.github" \
-                                  --host=arm64 \
-                                  --build=${{env.BUILD_ARCH}} \
-                                  --dist=${{inputs.distro-codename}} \
-                                  $lintian_flag \
-                                  --build-dir $BUILD_DIR_ABS \
-                                  --build-dep-resolver=apt"
+                                   --host=arm64 \
+                                   --build=${{env.BUILD_ARCH}} \
+                                   --dist=${{inputs.suite}} \
+                                   $lintian_flag \
+                                   --build-dir $BUILD_DIR_ABS \
+                                   --build-dep-resolver=apt"
         fi
 
         RET=$?

--- a/.github/pkg-workflows/debian/pr-pre-post-merge.yml
+++ b/.github/pkg-workflows/debian/pr-pre-post-merge.yml
@@ -22,3 +22,4 @@ jobs:
       # PRE-MERGE: use the PR head branch (github.head_ref)
       # POST-MERGE: use the base branch name from the PR (e.g. "debian/qcom-next")
       debian-ref: ${{ (github.event.action == 'closed' && github.event.pull_request.merged) && github.event.pull_request.base.ref || github.head_ref }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}

--- a/.github/pkg-workflows/debian/pr-pre-post-merge.yml
+++ b/.github/pkg-workflows/debian/pr-pre-post-merge.yml
@@ -1,0 +1,24 @@
+name: PR Pre and Post Merge Build
+
+on:
+  pull_request:
+    branches: [ debian/*, qcom/** ]
+    types: [ opened, synchronize, reopened, closed ]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    # This condition ensures that the job runs for all PR actions except closed unmerged,
+    # i.e., it runs for opened, synchronize, reopened (pre-merge) and closed merged (post-merge).
+
+    name: Build Debian Package
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-build-pkg-reusable-workflow.yml@main
+    if: ${{ github.event.action != 'closed' || github.event.pull_request.merged == true }}
+    with:
+      qcom-build-utils-ref: main
+      # PRE-MERGE: use the PR head branch (github.head_ref)
+      # POST-MERGE: use the base branch name from the PR (e.g. "debian/qcom-next")
+      debian-ref: ${{ (github.event.action == 'closed' && github.event.pull_request.merged) && github.event.pull_request.base.ref || github.head_ref }}

--- a/.github/pkg-workflows/main/build-debian-package.yml
+++ b/.github/pkg-workflows/main/build-debian-package.yml
@@ -37,3 +37,4 @@ jobs:
       qcom-build-utils-ref: main
       debian-ref: ${{ inputs.debian-ref }}
       suite: ${{ inputs.suite }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}

--- a/.github/pkg-workflows/main/build-debian-package.yml
+++ b/.github/pkg-workflows/main/build-debian-package.yml
@@ -1,0 +1,39 @@
+name: Build Debian Package
+description: |
+  Builds the debian package represented by this repo at the ref pointed by the debain-ref argument.
+
+on:
+  workflow_dispatch:
+    inputs:
+
+      debian-ref:
+        description: The debian ref to build. For example branch "debian/qcom-next" or tag "debian/1.0.0-1"
+        type: string
+        required: true
+        default: debian/qcom-next
+
+      suite:
+        description: The distribution codename or Debian suite to build for. Ex noble, questing, resolute, trixie, sid, unstable
+        type: choice
+        default: unstable
+        options:
+          - noble
+          - questing
+          - resolute
+          - unstable
+          - forky
+          - trixie
+          - bookworm
+          - sid
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-build-pkg-reusable-workflow.yml@main
+    with:
+      qcom-build-utils-ref: main
+      debian-ref: ${{ inputs.debian-ref }}
+      suite: ${{ inputs.suite }}

--- a/.github/pkg-workflows/main/promote-prebuilt.yml
+++ b/.github/pkg-workflows/main/promote-prebuilt.yml
@@ -1,0 +1,50 @@
+name: Promote New Prebuilt Binary Version
+
+on:
+  workflow_dispatch:
+    inputs:
+
+      debian-branch:
+        description: The debian branch to apply the promotion to. For example "debian/qcom-next"
+        type: string
+        required: false
+        default: debian/qcom-next
+
+      new-tag:
+        description: |
+          The new Artifactory TAG to promote to (e.g. 251030.2).
+          This is the TAG field in upstream.conf.
+        type: string
+        required: true
+
+      new-package-name:
+        description: |
+          The new tarball filename if it has changed (e.g. qcom-adreno_1.838.2_armv8-2a.tar.gz).
+          Leave empty to keep the current PACKAGE_NAME in upstream.conf unchanged.
+        type: string
+        required: false
+        default: ""
+
+      new-debian-version:
+        description: |
+          The new debian changelog version (e.g. 1.838.2~251030 or 1.838.2-1).
+          If omitted, the version is automatically derived from the PACKAGE_NAME
+          (e.g. qcom-adreno_1.838.2_armv8-2a.tar.gz -> 1.838.2-1).
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote:
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml@dev/pkg-bin
+    with:
+      qcom-build-utils-ref: dev/pkg-bin
+      debian-branch: ${{inputs.debian-branch}}
+      new-tag: ${{inputs.new-tag}}
+      new-package-name: ${{inputs.new-package-name}}
+      new-debian-version: ${{inputs.new-debian-version}}
+    secrets: inherit

--- a/.github/pkg-workflows/main/promote-upstream.yml
+++ b/.github/pkg-workflows/main/promote-upstream.yml
@@ -1,0 +1,33 @@
+name: Promote New Upstream Version
+
+on:
+  workflow_dispatch:
+    inputs:
+
+      debian-branch:
+        description: The debian branch to apply the promotion to. For example branch "debian/qcom-next"
+        type: string
+        required: false
+        default: debian/qcom-next
+
+      upstream-tag:
+        description: The upstream tag to promote this package repo to. Eg, v1.1.0 or 1.2.0, depending on the versioning style
+        type: string
+        required: true
+
+permissions:
+  contents: write
+  packages: read
+  pull-requests: write
+
+jobs:
+  promote:
+
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-promote-upstream-reusable-workflow.yml@main
+    with:
+      qcom-build-utils-ref: main
+      debian-branch: ${{inputs.debian-branch}}
+      upstream-tag: ${{inputs.upstream-tag}}
+      upstream-repo: ${{vars.UPSTREAM_REPO_GITHUB_NAME}}
+    secrets:
+      PAT: ${{secrets.DEB_PKG_BOT_CI_TOKEN}} # If the source repo is private, this secret is necessary to be provided in the repo

--- a/.github/pkg-workflows/main/release.yml
+++ b/.github/pkg-workflows/main/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
 
-      distro-codename:
+      suite:
         description: The distribution codename or Debian suite to release for. Ex noble, questing, resolute, trixie, bookworm, sid, unstable
         type: choice
         default: noble
@@ -43,7 +43,7 @@ jobs:
     uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-release-reusable-workflow.yml@main
     with:
       qcom-build-utils-ref: main
-      distro-codename: ${{ github.event.inputs.distro-codename }}
+      suite: ${{ github.event.inputs.suite }}
       debian-branch: ${{ github.event.inputs.debian-branch }}
       test-run: ${{ github.event.inputs.test-run == 'true' && true || false }}
     secrets:

--- a/.github/pkg-workflows/main/release.yml
+++ b/.github/pkg-workflows/main/release.yml
@@ -40,12 +40,14 @@ permissions:
 
 jobs:
   release:
+
     uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-release-reusable-workflow.yml@main
     with:
       qcom-build-utils-ref: main
       suite: ${{ github.event.inputs.suite }}
       debian-branch: ${{ github.event.inputs.debian-branch }}
       test-run: ${{ github.event.inputs.test-run == 'true' && true || false }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}
     secrets:
       PAT: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
       DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}

--- a/.github/pkg-workflows/main/release.yml
+++ b/.github/pkg-workflows/main/release.yml
@@ -1,0 +1,53 @@
+name: Release Version
+description: |
+  Release a new package version.
+  This workflow is manually triggered via workflow_dispatch.
+
+on:
+  workflow_dispatch:
+    inputs:
+
+      distro-codename:
+        description: The distribution codename or Debian suite to release for. Ex noble, questing, resolute, trixie, bookworm, sid, unstable
+        type: choice
+        default: noble
+        options:
+          - noble
+          - questing
+          - resolute
+          - unstable
+          - forky
+          - trixie
+          - bookworm
+          - sid
+
+      debian-branch:
+        description: The debian branch to use to execute the release from. For example branch "debian/qcom-next"
+        type: string
+        required: false
+        default: debian/qcom-next
+
+      test-run:
+        description: |
+          Debian suites: if true, stop after the Debusine build and installability test.
+          Ubuntu codenames: preserve the previous release flow, including upload to the test S3 location.
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  packages: read
+
+jobs:
+  release:
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-release-reusable-workflow.yml@main
+    with:
+      qcom-build-utils-ref: main
+      distro-codename: ${{ github.event.inputs.distro-codename }}
+      debian-branch: ${{ github.event.inputs.debian-branch }}
+      test-run: ${{ github.event.inputs.test-run == 'true' && true || false }}
+    secrets:
+      PAT: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
+      DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+      DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+      DEBUSINE_RELEASE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -53,6 +53,11 @@ on:
         type: boolean
         default: false
 
+      debusine-parent-workspace:
+        description: Parent Debusine workspace used to create per-run child CI workspaces for Debian builds
+        type: string
+        default: ci
+
     secrets:
       DEBUSINE_USER:
         required: false
@@ -256,7 +261,7 @@ jobs:
           DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
           DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
           DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
-          DEBUSINE_PARENT_WORKSPACE: ci
+          DEBUSINE_PARENT_WORKSPACE: ${{ inputs.debusine-parent-workspace }}
           SUITE: ${{ needs.resolve.outputs.target_suite }}
         run: |
           set -euxo pipefail

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -1,8 +1,9 @@
 name: Qualcomm Build Debian Package Reusable Workflow
 description: |
-  This reusable workflow is called by debian-packaging repos to offer a consistent build process.
-  Package repos will adhere to  a git-buildpackage structure and contain the small "build-debian-package.yml"
-  caller workflow in its .github/workflows folder.
+  This reusable workflow is called by debian-packaging repos to offer a consistent
+  build-and-test process.
+  Debian suites use the Debusine build service, while Ubuntu codenames keep using
+  the local pkg-builder container flow.
 
 on:
   workflow_call:
@@ -18,61 +19,146 @@ on:
         required: true
         default: debian/qcom-next
 
-      distro-codename:
-        description: The distribution codename to build for. Ex noble, jammy, etc
+      suite:
+        description: The distribution codename or Debian suite to build for. Preferred input for newer callers.
         type: string
-        default: noble
+        default: ""
+
+      distro-codename:
+        description: Legacy alias for suite, kept for backward compatibility with older callers.
+        type: string
+        default: ""
 
       run-lintian:
-        description: Run lintian or not during the build
+        description: Run lintian or not during the Ubuntu pkg-builder build path
         type: boolean
         default: true
 
       run-abi-checker:
-        description: Run the ABI checker or not
+        description: Run the ABI checker or not during the Ubuntu pkg-builder build path
         type: boolean
         default: false
 
       is-prebuilt:
         description: |
-          Controls the build mode passed to the build_package action:
+          Controls the build mode passed to the Ubuntu build_package action:
             "true"  — Force prebuilt binary mode.
             "false" — Force source build mode.
             ""      — Auto-detect (default): prebuilt if upstream.conf exists in the repo, else source.
-          Leaving this unset is recommended for use with pkg-template so that the same workflow
-          works for both source and binary packages without modification.
         type: string
         default: ""
+
+      job-index:
+        description: Uniquely identifying index for matrix-expanded callers so Debusine child workspaces stay distinct
+        type: string
+        default: "0"
+
+      release:
+        description: Prepare a release bundle (finalizes changelog, creates git bundle for push-release) for the Debian Debusine path
+        type: boolean
+        default: false
+
+    secrets:
+      DEBUSINE_USER:
+        required: false
+      DEBUSINE_TOKEN:
+        required: false
+
+    outputs:
+      target_suite:
+        description: The resolved suite/codename actually used by the workflow
+        value: ${{ jobs.finalize.outputs.target_suite }}
+      workspace:
+        description: Debusine workspace ID for Debian builds; empty for Ubuntu builds
+        value: ${{ jobs.finalize.outputs.workspace }}
+      workspace_url:
+        description: Debusine workspace URL for Debian builds; empty for Ubuntu builds
+        value: ${{ jobs.finalize.outputs.workspace_url }}
+      srcpkg_name:
+        description: Source package name
+        value: ${{ jobs.finalize.outputs.srcpkg_name }}
+      srcpkg_version:
+        description: Source package version
+        value: ${{ jobs.finalize.outputs.srcpkg_version }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.release && 'release' || github.run_id }}
 
 permissions:
   contents: read
   packages: read
 
+env:
+  DEBUSINE_ACTION_REF: main
+
 jobs:
-  build-debian-package:
+  resolve:
+    name: Resolve suite family
+    runs-on: ubuntu-latest
+    outputs:
+      family: ${{ steps.resolve.outputs.family }}
+      target_suite: ${{ steps.resolve.outputs.target_suite }}
+      debian_builder_suite: ${{ steps.resolve.outputs.debian_builder_suite }}
+    steps:
+      - name: Classify suite
+        id: resolve
+        shell: bash
+        env:
+          SUITE_INPUT: ${{ inputs.suite }}
+          DISTRO_CODENAME_INPUT: ${{ inputs.distro-codename }}
+        run: |
+          set -euo pipefail
 
+          if [[ -n "$SUITE_INPUT" ]]; then
+            target_suite="$SUITE_INPUT"
+          elif [[ -n "$DISTRO_CODENAME_INPUT" ]]; then
+            target_suite="$DISTRO_CODENAME_INPUT"
+          else
+            target_suite=unstable
+          fi
+
+          case "$target_suite" in
+            trixie|sid|unstable|bookworm|forky)
+              family=debian
+              ;;
+            *)
+              family=ubuntu
+              ;;
+          esac
+
+          debian_builder_suite="$target_suite"
+          if [[ "$target_suite" == "unstable" ]]; then
+            debian_builder_suite=sid
+          fi
+
+          echo "family=$family" >> "$GITHUB_OUTPUT"
+          echo "target_suite=$target_suite" >> "$GITHUB_OUTPUT"
+          echo "debian_builder_suite=$debian_builder_suite" >> "$GITHUB_OUTPUT"
+
+  ubuntu-build:
+    name: Build (Ubuntu)
+    if: ${{ needs.resolve.outputs.family == 'ubuntu' }}
+    needs: resolve
     runs-on: ubuntu-24.04-arm
-
+    outputs:
+      srcpkg_name: ${{ steps.metadata.outputs.srcpkg_name }}
+      srcpkg_version: ${{ steps.metadata.outputs.srcpkg_version }}
     defaults:
       run:
         shell: bash
-
     container:
-      # This docker image is built and published by the qualcomm-linux/docker_deb_build repo CI workflow
-      image: ghcr.io/qualcomm-linux/pkg-builder:${{inputs.distro-codename}}
+      image: ghcr.io/qualcomm-linux/pkg-builder:${{ needs.resolve.outputs.target_suite }}
       options: --privileged
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
     steps:
-
       - name: Checkout qcom-build-utils
         uses: actions/checkout@v5
         with:
           repository: qualcomm-linux/qcom-build-utils
-          ref: ${{inputs.qcom-build-utils-ref}}
-          path: ./qcom-build-utils
+          ref: ${{ inputs.qcom-build-utils-ref }}
+          path: qcom-build-utils
           fetch-depth: 1
           sparse-checkout: |
             .github
@@ -81,22 +167,225 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
         with:
-          ref: ${{inputs.debian-ref}}
-          path: ./package-repo
-          fetch-depth: 0 # <- Important for the tags fetching to work
-          fetch-tags: true # <- Important
+          ref: ${{ inputs.debian-ref }}
+          path: package-repo
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Collect source package metadata
+        id: metadata
+        run: |
+          cd package-repo
+          echo "srcpkg_name=$(dpkg-parsechangelog --show-field Source)" >> "$GITHUB_OUTPUT"
+          echo "srcpkg_version=$(dpkg-parsechangelog --show-field Version)" >> "$GITHUB_OUTPUT"
 
       - name: Build Debian Packages
         uses: ./qcom-build-utils/.github/actions/build_package
         with:
-          distro-codename: ${{inputs.distro-codename}}
+          distro-codename: ${{ needs.resolve.outputs.target_suite }}
           pkg-dir: package-repo
           build-dir: build-area
-          run-lintian: ${{inputs.run-lintian}}
-          prebuilt: ${{inputs.is-prebuilt}}
+          run-lintian: ${{ inputs.run-lintian }}
+          prebuilt: ${{ inputs.is-prebuilt }}
 
       - name: Run ABI (Application Binary Interface) Check
-        if: ${{inputs.run-abi-checker == true}}
+        if: ${{ inputs.run-abi-checker }}
         uses: ./qcom-build-utils/.github/actions/abi_checker
         with:
-          apt-repository: "deb [arch=arm64 trusted=yes] https://qartifactory-edge.qualcomm.com/artifactory/qsc-deb-releases ${{inputs.distro-codename}} main"
+          apt-repository: "deb [arch=arm64 trusted=yes] https://qartifactory-edge.qualcomm.com/artifactory/qsc-deb-releases ${{ needs.resolve.outputs.target_suite }} main"
+
+  debian-build:
+    name: Build (Debian)
+    if: ${{ needs.resolve.outputs.family == 'debian' }}
+    needs: resolve
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/qualcomm-linux/debusine-pkg-builder:${{ needs.resolve.outputs.debian_builder_suite }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      workspace: ${{ steps.prepare-debusine.outputs.workspace }}
+      workspace_url: ${{ steps.prepare-debusine.outputs.workspace_url }}
+      srcpkg_name: ${{ steps.generate-source-package.outputs.srcpkg_name }}
+      srcpkg_version: ${{ steps.generate-source-package.outputs.srcpkg_version }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Require Debusine token
+        env:
+          DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+        run: |
+          if [ -z "$DEBUSINE_TOKEN" ]; then
+            echo "DEBUSINE_TOKEN is required for Debian/Debusine builds" >&2
+            exit 1
+          fi
+
+      - name: Checkout debusine-action helpers
+        uses: actions/checkout@v5
+        with:
+          repository: qualcomm-linux/debusine-action
+          ref: ${{ env.DEBUSINE_ACTION_REF }}
+          path: debusine-action
+          fetch-depth: 1
+          sparse-checkout: |
+            lib
+
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.debian-ref }}
+          path: srcpkg
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Prepare release
+        if: ${{ inputs.release }}
+        env:
+          SUITE_INPUT: ${{ needs.resolve.outputs.target_suite }}
+        run: |
+          set -ex
+          echo "::group::Prepare release"
+          SUITE="$SUITE_INPUT" debusine-action/lib/prepare-release
+          echo "::endgroup::"
+
+      - name: Generate source package
+        id: generate-source-package
+        env:
+          SUITE_INPUT: ${{ needs.resolve.outputs.target_suite }}
+        run: |
+          set -ex
+          SUITE="$SUITE_INPUT" debusine-action/lib/generate-source-package
+
+      - name: Build in Debusine
+        id: prepare-debusine
+        env:
+          GITHUB_REPOSITORY_ID: ${{ github.repository_id }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          JOB_INDEX: ${{ inputs.job-index }}
+          DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
+          DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
+          DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+          DEBUSINE_PARENT_WORKSPACE: ci
+          SUITE: ${{ needs.resolve.outputs.target_suite }}
+        run: |
+          set -euxo pipefail
+          debusine-action/lib/build
+          cat output >> "$GITHUB_OUTPUT"
+          workspace=$(sed -n 's/^workspace=//p' output)
+          echo "workspace_url=https://${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${workspace}/" >> "$GITHUB_OUTPUT"
+
+      - name: Note Debusine workspace URL
+        run: |
+          echo "Debusine Workspace URL: ${{ steps.prepare-debusine.outputs.workspace_url }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release bundle
+        if: ${{ inputs.release }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-bundle
+          path: release.bundle
+          if-no-files-found: error
+
+  debian-test:
+    name: Test (Debian)
+    if: ${{ needs.resolve.outputs.family == 'debian' }}
+    needs:
+      - resolve
+      - debian-build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/qualcomm-linux/debusine-pkg-builder:${{ needs.resolve.outputs.debian_builder_suite }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Require Debusine credentials
+        env:
+          DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+          DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+        run: |
+          if [ -z "$DEBUSINE_USER" ] || [ -z "$DEBUSINE_TOKEN" ]; then
+            echo "DEBUSINE_USER and DEBUSINE_TOKEN are required for Debian/Debusine tests" >&2
+            exit 1
+          fi
+
+      - name: Checkout debusine-action helpers
+        uses: actions/checkout@v5
+        with:
+          repository: qualcomm-linux/debusine-action
+          ref: ${{ env.DEBUSINE_ACTION_REF }}
+          path: debusine-action
+          fetch-depth: 1
+          sparse-checkout: |
+            lib
+
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.debian-ref }}
+          path: srcpkg
+          fetch-depth: 1
+
+      - name: Validate installability from Debusine CI workspace
+        env:
+          DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
+          DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
+          DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+          DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+          DEBUSINE_WORKSPACE: ${{ needs.debian-build.outputs.workspace }}
+          SUITE: ${{ needs.resolve.outputs.target_suite }}
+        run: |
+          set -euxo pipefail
+
+          debusine-action/lib/generate-apt-config
+          install -d /etc/apt/sources.list.d /etc/apt/auth.conf.d
+          install -m 0644 debusine-ci.sources /etc/apt/sources.list.d/debusine-ci.sources
+          install -m 0600 debusine-ci-auth.conf /etc/apt/auth.conf.d/debusine-ci-auth.conf
+          apt-get update
+
+          packages=$(grep-dctrl -n -s Package -r '' srcpkg/debian/control | sort -u | paste -sd ' ' -)
+          if [ -z "$packages" ]; then
+            echo "No binary packages found in srcpkg/debian/control" >&2
+            exit 1
+          fi
+
+          env DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y $packages
+
+  finalize:
+    name: Finalize outputs
+    needs:
+      - resolve
+      - ubuntu-build
+      - debian-build
+      - debian-test
+    runs-on: ubuntu-latest
+    outputs:
+      target_suite: ${{ steps.select.outputs.target_suite }}
+      workspace: ${{ steps.select.outputs.workspace }}
+      workspace_url: ${{ steps.select.outputs.workspace_url }}
+      srcpkg_name: ${{ steps.select.outputs.srcpkg_name }}
+      srcpkg_version: ${{ steps.select.outputs.srcpkg_version }}
+    steps:
+      - name: Select workflow outputs
+        id: select
+        shell: bash
+        run: |
+          if [[ "${{ needs.resolve.outputs.family }}" == "debian" ]]; then
+            echo "target_suite=${{ needs.resolve.outputs.target_suite }}" >> "$GITHUB_OUTPUT"
+            echo "workspace=${{ needs.debian-build.outputs.workspace }}" >> "$GITHUB_OUTPUT"
+            echo "workspace_url=${{ needs.debian-build.outputs.workspace_url }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_name=${{ needs.debian-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_version=${{ needs.debian-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "target_suite=${{ needs.resolve.outputs.target_suite }}" >> "$GITHUB_OUTPUT"
+            echo "workspace=" >> "$GITHUB_OUTPUT"
+            echo "workspace_url=" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_name=${{ needs.ubuntu-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_version=${{ needs.ubuntu-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -20,14 +20,9 @@ on:
         default: debian/qcom-next
 
       suite:
-        description: The distribution codename or Debian suite to build for. Preferred input for newer callers.
+        description: The distribution codename or Debian suite to build for. Ex noble, questing, resolute, trixie, sid, unstable
         type: string
-        default: ""
-
-      distro-codename:
-        description: Legacy alias for suite, kept for backward compatibility with older callers.
-        type: string
-        default: ""
+        default: unstable
 
       run-lintian:
         description: Run lintian or not during the Ubuntu pkg-builder build path
@@ -105,17 +100,10 @@ jobs:
         shell: bash
         env:
           SUITE_INPUT: ${{ inputs.suite }}
-          DISTRO_CODENAME_INPUT: ${{ inputs.distro-codename }}
         run: |
           set -euo pipefail
 
-          if [[ -n "$SUITE_INPUT" ]]; then
-            target_suite="$SUITE_INPUT"
-          elif [[ -n "$DISTRO_CODENAME_INPUT" ]]; then
-            target_suite="$DISTRO_CODENAME_INPUT"
-          else
-            target_suite=unstable
-          fi
+          target_suite="$SUITE_INPUT"
 
           case "$target_suite" in
             trixie|sid|unstable|bookworm|forky)
@@ -182,7 +170,7 @@ jobs:
       - name: Build Debian Packages
         uses: ./qcom-build-utils/.github/actions/build_package
         with:
-          distro-codename: ${{ needs.resolve.outputs.target_suite }}
+          suite: ${{ needs.resolve.outputs.target_suite }}
           pkg-dir: package-repo
           build-dir: build-area
           run-lintian: ${{ inputs.run-lintian }}

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -187,6 +187,18 @@ jobs:
         with:
           apt-repository: "deb [arch=arm64 trusted=yes] https://qartifactory-edge.qualcomm.com/artifactory/qsc-deb-releases ${{ needs.resolve.outputs.target_suite }} main"
 
+      - name: Upload Ubuntu build artifacts
+        run: |
+          set -euxo pipefail
+          tar -C build-area -czf ubuntu-build-area.tgz .
+
+      - name: Upload Ubuntu build archive
+        uses: actions/upload-artifact@v6
+        with:
+          name: ubuntu-build-area
+          path: ubuntu-build-area.tgz
+          if-no-files-found: error
+
   debian-build:
     name: Build (Debian)
     if: ${{ needs.resolve.outputs.family == 'debian' }}
@@ -194,6 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/qualcomm-linux/debusine-pkg-builder:${{ needs.resolve.outputs.debian_builder_suite }}
+      options: --user 0:0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -282,15 +295,22 @@ jobs:
           path: release.bundle
           if-no-files-found: error
 
-  debian-test:
-    name: Test (Debian)
-    if: ${{ needs.resolve.outputs.family == 'debian' }}
+  test:
+    name: Test
+    if: ${{ always() && ((needs.resolve.outputs.family == 'debian' && needs.debian-build.result == 'success') || (needs.resolve.outputs.family == 'ubuntu' && needs.ubuntu-build.result == 'success')) }}
     needs:
       - resolve
       - debian-build
-    runs-on: ubuntu-latest
+      - ubuntu-build
+    outputs:
+      workspace: ${{ steps.select.outputs.workspace }}
+      workspace_url: ${{ steps.select.outputs.workspace_url }}
+      srcpkg_name: ${{ steps.select.outputs.srcpkg_name }}
+      srcpkg_version: ${{ steps.select.outputs.srcpkg_version }}
+    runs-on: ${{ needs.resolve.outputs.family == 'debian' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     container:
-      image: ghcr.io/qualcomm-linux/debusine-pkg-builder:${{ needs.resolve.outputs.debian_builder_suite }}
+      image: ${{ needs.resolve.outputs.family == 'debian' && format('ghcr.io/qualcomm-linux/debusine-pkg-builder:{0}', needs.resolve.outputs.debian_builder_suite) || format('ghcr.io/qualcomm-linux/pkg-builder:{0}', needs.resolve.outputs.target_suite) }}
+      options: --user 0:0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -299,6 +319,7 @@ jobs:
         shell: bash
     steps:
       - name: Require Debusine credentials
+        if: ${{ needs.resolve.outputs.family == 'debian' }}
         env:
           DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
           DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
@@ -309,6 +330,7 @@ jobs:
           fi
 
       - name: Checkout debusine-action helpers
+        if: ${{ needs.resolve.outputs.family == 'debian' }}
         uses: actions/checkout@v5
         with:
           repository: qualcomm-linux/debusine-action
@@ -319,6 +341,7 @@ jobs:
             lib
 
       - name: Checkout Repository
+        if: ${{ needs.resolve.outputs.family == 'debian' }}
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.debian-ref }}
@@ -326,6 +349,7 @@ jobs:
           fetch-depth: 1
 
       - name: Validate installability from Debusine CI workspace
+        if: ${{ needs.resolve.outputs.family == 'debian' }}
         env:
           DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
           DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
@@ -337,9 +361,44 @@ jobs:
           set -euxo pipefail
 
           debusine-action/lib/generate-apt-config
-          install -d /etc/apt/sources.list.d /etc/apt/auth.conf.d
+          install -d /etc/apt/keyrings /etc/apt/sources.list.d /etc/apt/auth.conf.d
           install -m 0644 debusine-ci.sources /etc/apt/sources.list.d/debusine-ci.sources
           install -m 0600 debusine-ci-auth.conf /etc/apt/auth.conf.d/debusine-ci-auth.conf
+
+          qartifactory_suite="$SUITE"
+          if [ "$qartifactory_suite" = "unstable" ]; then
+            qartifactory_suite=sid
+          fi
+
+          case "$qartifactory_suite" in
+            noble|questing|resolute|trixie|sid)
+              cat > /etc/apt/keyrings/qsc-deb-releases.asc <<'EOF'
+          -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+          mDMEaGwEMxYJKwYBBAHaRw8BAQdAg8Nfdby/c9Y6bctGLnGJrhMhedCGfYzrp9Sa
+          RWtQgDe0NXFzY19hcHRfcmVwby0wNzA3MjAyNSA8YXJ0aWZhY3RvcnkuY29yZUBx
+          dWFsY29tbS5jb20+iJkEExYKAEEWIQRyQhNJGZOZvf1sqY3IwASzX5SqWwUCaGwE
+          MwIbAwUJBaOagAULCQgHAgIiAgYVCgkICwIEFgIDAQIeBwIXgAAKCRDIwASzX5Sq
+          W0k4AQCzVUgf+ydkoHdxKiHzwZjDowL38lAp92zlvQqK2r+9kQEAxZYBhPQ4ZVo9
+          RL2bOrJexNAJyYqRamtrU+jkBn1wjQq4OARobAQzEgorBgEEAZdVAQUBAQdASOGZ
+          gHVoc7BboK7yCC3bSib9NLBlrsA47RRvT7fPHhoDAQgHiH4EGBYKACYWIQRyQhNJ
+          GZOZvf1sqY3IwASzX5SqWwUCaGwEMwIbDAUJBaOagAAKCRDIwASzX5SqWzH3AP94
+          HDue14QrgcEsyXCElAAZxYqiDMFu663G3ki0lGB1vAEAz0tqLiapgthdSt/c/2YQ
+          tej7g/77RkEpjjhnWiLMiAM=
+          =7H+M
+          -----END PGP PUBLIC KEY BLOCK-----
+          EOF
+              cat > /etc/apt/sources.list.d/qsc-deb-releases.sources <<EOF
+          Types: deb
+          URIs: https://qartifactory-edge.qualcomm.com/artifactory/qsc-deb-releases
+          Suites: $qartifactory_suite
+          Components: main
+          Signed-By: /etc/apt/keyrings/qsc-deb-releases.asc
+          Enabled: yes
+          EOF
+              ;;
+          esac
+
           apt-get update
 
           packages=$(grep-dctrl -n -s Package -r '' srcpkg/debian/control | sort -u | paste -sd ' ' -)
@@ -350,13 +409,56 @@ jobs:
 
           env DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y $packages
 
+      - name: Download Ubuntu build artifacts
+        if: ${{ needs.resolve.outputs.family == 'ubuntu' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ubuntu-build-area
+          path: .
+
+      - name: Extract Ubuntu build artifacts
+        if: ${{ needs.resolve.outputs.family == 'ubuntu' }}
+        run: |
+          set -euxo pipefail
+          mkdir -p build-area
+          tar -C build-area -xzf ubuntu-build-area.tgz
+
+      - name: Validate installability from Ubuntu build artifacts
+        if: ${{ needs.resolve.outputs.family == 'ubuntu' }}
+        run: |
+          set -euxo pipefail
+
+          apt-get update
+
+          debs=$(find "$PWD/build-area" -type f -name '*.deb' | sort)
+          if [ -z "$debs" ]; then
+            echo "No binary packages found in build-area" >&2
+            exit 1
+          fi
+
+          env DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y $debs
+
+      - name: Select test outputs
+        id: select
+        run: |
+          if [[ "${{ needs.resolve.outputs.family }}" == "debian" ]]; then
+            echo "workspace=${{ needs.debian-build.outputs.workspace }}" >> "$GITHUB_OUTPUT"
+            echo "workspace_url=${{ needs.debian-build.outputs.workspace_url }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_name=${{ needs.debian-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_version=${{ needs.debian-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "workspace=" >> "$GITHUB_OUTPUT"
+            echo "workspace_url=" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_name=${{ needs.ubuntu-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_version=${{ needs.ubuntu-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+          fi
+
   finalize:
     name: Finalize outputs
+    if: ${{ always() && needs.resolve.result == 'success' && needs.test.result == 'success' }}
     needs:
       - resolve
-      - ubuntu-build
-      - debian-build
-      - debian-test
+      - test
     runs-on: ubuntu-latest
     outputs:
       target_suite: ${{ steps.select.outputs.target_suite }}
@@ -369,16 +471,8 @@ jobs:
         id: select
         shell: bash
         run: |
-          if [[ "${{ needs.resolve.outputs.family }}" == "debian" ]]; then
-            echo "target_suite=${{ needs.resolve.outputs.target_suite }}" >> "$GITHUB_OUTPUT"
-            echo "workspace=${{ needs.debian-build.outputs.workspace }}" >> "$GITHUB_OUTPUT"
-            echo "workspace_url=${{ needs.debian-build.outputs.workspace_url }}" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_name=${{ needs.debian-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_version=${{ needs.debian-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "target_suite=${{ needs.resolve.outputs.target_suite }}" >> "$GITHUB_OUTPUT"
-            echo "workspace=" >> "$GITHUB_OUTPUT"
-            echo "workspace_url=" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_name=${{ needs.ubuntu-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_version=${{ needs.ubuntu-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "target_suite=${{ needs.resolve.outputs.target_suite }}" >> "$GITHUB_OUTPUT"
+          echo "workspace=${{ needs.test.outputs.workspace }}" >> "$GITHUB_OUTPUT"
+          echo "workspace_url=${{ needs.test.outputs.workspace_url }}" >> "$GITHUB_OUTPUT"
+          echo "srcpkg_name=${{ needs.test.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
+          echo "srcpkg_version=${{ needs.test.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -1,10 +1,8 @@
-name: Release Promotion Workflow
+name: Qualcomm Release Debian Package Reusable Workflow
 description: |
-  This reusable workflow is called by a user to create a release of the package. A release is the act of changing
-  the latest changelog entry's 'suite' from UNRELEASED to unstable, building the package, committing the changelog change,
-  tagging the release commit, and bumping the changelog for the next development cycle. 
-  At last, the built package is uploaded to a private S3 bucket for later retrieval. Included alongside the built package
-  is a provenance file containing metadata about the source and package repositories and commits.
+  This reusable workflow performs a package release.
+  Debian suites use the Debusine-backed release path, while Ubuntu codenames keep
+  using the local pkg-builder and S3 release flow.
 
 on:
   workflow_call:
@@ -21,52 +19,200 @@ on:
         default: debian/qcom-next
 
       distro-codename:
-        description: The distribution codename to build for. Ex noble, jammy, etc
+        description: The distribution codename or Debian suite to build and release for. Ex noble, questing, resolute, trixie, sid
         type: string
         default: noble
 
       test-run:
-        description: true if this is a test run. Packages will be uploaded in test folder in S3
+        description: |
+          Debian path: if true, stop after the Debusine build and installability test.
+          Ubuntu path: preserve the previous release flow, including upload to the test S3 location.
         type: boolean
         default: true
 
     secrets:
       PAT:
-        description: Personal Access Token with repo and package permissions to the packaging repository. This is needed to push the changelog commit and tag to the packaging repository.
+        description: Personal Access Token with repo permissions to the packaging repository. Needed to check out and push release git state.
+        required: true
+      DEBUSINE_USER:
+        description: Debusine user name used for CI workspace access and apt authentication in the Debian test gate.
         required: false
+      DEBUSINE_TOKEN:
+        description: Debusine CI token used to create the child workspace and validate installability from it for Debian suites.
+        required: false
+      DEBUSINE_RELEASE_TOKEN:
+        description: Debusine production token used only for the Debian publish-to-prod step.
+        required: false
+
+    outputs:
+      workspace:
+        description: Debusine child workspace name for Debian releases; empty for Ubuntu releases
+        value: ${{ jobs.finalize.outputs.workspace }}
+      workspace_url:
+        description: Debusine web URL for the child workspace for Debian releases; empty for Ubuntu releases
+        value: ${{ jobs.finalize.outputs.workspace_url }}
+      srcpkg_name:
+        description: Source package name prepared for release
+        value: ${{ jobs.finalize.outputs.srcpkg_name }}
+      srcpkg_version:
+        description: Source package version prepared for release
+        value: ${{ jobs.finalize.outputs.srcpkg_version }}
+      complete_version:
+        description: Alias for the released source package version
+        value: ${{ jobs.finalize.outputs.complete_version }}
 
 permissions:
   contents: read
   packages: read
 
+env:
+  DEBUSINE_ACTION_REF: dev/sbeaudoi
+
 jobs:
-  pkg-release:
-
-    runs-on: ubuntu-24.04-arm
-
+  resolve:
+    name: Resolve suite family
+    runs-on: ubuntu-latest
     outputs:
-      complete_version: ${{ steps.changelog.outputs.version }}
+      family: ${{ steps.resolve.outputs.family }}
+      debian_builder_suite: ${{ steps.resolve.outputs.debian_builder_suite }}
+    steps:
+      - name: Classify suite
+        id: resolve
+        shell: bash
+        env:
+          TARGET_SUITE: ${{ inputs.distro-codename }}
+        run: |
+          set -euo pipefail
 
+          case "$TARGET_SUITE" in
+            trixie|sid|unstable|bookworm|forky)
+              family=debian
+              ;;
+            *)
+              family=ubuntu
+              ;;
+          esac
+
+          debian_builder_suite="$TARGET_SUITE"
+          if [[ "$TARGET_SUITE" == "unstable" ]]; then
+            debian_builder_suite=sid
+          fi
+
+          echo "family=$family" >> "$GITHUB_OUTPUT"
+          echo "debian_builder_suite=$debian_builder_suite" >> "$GITHUB_OUTPUT"
+
+  debian-build:
+    name: Build and Test (Debian)
+    if: ${{ needs.resolve.outputs.family == 'debian' }}
+    needs: resolve
+    uses: ./.github/workflows/qcom-build-pkg-reusable-workflow.yml
+    with:
+      qcom-build-utils-ref: ${{ inputs.qcom-build-utils-ref }}
+      debian-ref: ${{ inputs.debian-branch }}
+      suite: ${{ inputs.distro-codename }}
+      release: true
+    secrets:
+      DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+      DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+
+  debian-release:
+    name: Release (Debian)
+    if: ${{ needs.resolve.outputs.family == 'debian' && !inputs.test-run }}
+    needs:
+      - resolve
+      - debian-build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
     defaults:
       run:
         shell: bash
-
     container:
-      # This docker image is built and published by the qualcomm-linux/docker_deb_build repo CI workflow
-      image: ghcr.io/qualcomm-linux/pkg-builder:${{inputs.distro-codename}}
+      image: ghcr.io/qualcomm-linux/debusine-pkg-builder:${{ needs.resolve.outputs.debian_builder_suite }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout debusine-action helpers
+        uses: actions/checkout@v5
+        with:
+          repository: qualcomm-linux/debusine-action
+          ref: ${{ env.DEBUSINE_ACTION_REF }}
+          path: debusine-action
+          fetch-depth: 1
+          sparse-checkout: |
+            lib
+
+      - name: Checkout Packaging Repo
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.PAT }}
+          path: srcpkg
+          ref: ${{ inputs.debian-branch }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download release bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: release-bundle
+
+      - name: Require Debusine release token
+        env:
+          DEBUSINE_RELEASE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}
+        run: |
+          if [ -z "$DEBUSINE_RELEASE_TOKEN" ]; then
+            echo "DEBUSINE_RELEASE_TOKEN is required when publishing Debian releases" >&2
+            exit 1
+          fi
+
+      - name: Publish release to Debusine
+        env:
+          DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
+          DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
+          DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}
+          DEBUSINE_CI_WORKSPACE: ${{ needs.debian-build.outputs.workspace }}
+          DEBUSINE_TARGET_WORKSPACE: prod
+          SRCPKG_NAME: ${{ needs.debian-build.outputs.srcpkg_name }}
+          SRCPKG_VERSION: ${{ needs.debian-build.outputs.srcpkg_version }}
+          SUITE: ${{ inputs.distro-codename }}
+        run: |
+          set -euxo pipefail
+
+          debusine-action/lib/release
+
+      - name: Push release git state
+        run: |
+          set -euxo pipefail
+
+          debusine-action/lib/push-release
+
+  ubuntu-pkg-release:
+    name: Release (Ubuntu)
+    if: ${{ needs.resolve.outputs.family == 'ubuntu' }}
+    needs: resolve
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      complete_version: ${{ steps.changelog.outputs.version }}
+      srcpkg_name: ${{ steps.metadata.outputs.srcpkg_name }}
+      srcpkg_version: ${{ steps.changelog.outputs.version }}
+    defaults:
+      run:
+        shell: bash
+    container:
+      image: ghcr.io/qualcomm-linux/pkg-builder:${{ inputs.distro-codename }}
       options: --privileged
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
     steps:
-
       - name: Checkout qcom-build-utils
         uses: actions/checkout@v5
         with:
           repository: qualcomm-linux/qcom-build-utils
-          ref: ${{inputs.qcom-build-utils-ref}}
-          path: ./qcom-build-utils
+          ref: ${{ inputs.qcom-build-utils-ref }}
+          path: qcom-build-utils
           fetch-depth: 1
           sparse-checkout: |
             .github
@@ -75,17 +221,18 @@ jobs:
       - name: Checkout Packaging Repo
         uses: actions/checkout@v5
         with:
-          token: ${{secrets.PAT}}
-          path: ./package-repo
+          token: ${{ secrets.PAT }}
+          path: package-repo
+          ref: ${{ inputs.debian-branch }}
           fetch-depth: 0
           fetch-tags: true
 
-      # Take the latest changelog entry and change the suite name from UNRELEASED to unstable and set timestamp and tag
-      # the inputs.debian-branch branch to <distro-codename>/<version> (e.g. noble/1.0.0-1) where <version> is the version
-      # from the changelog. Using the distro-codename as the tag prefix ensures uniqueness when the same upstream version is
-      # released to multiple distribution branches (e.g. noble, trixie). It is conceptually important that the changelog entry
-      # suite is UNRELEASED at any point except in the commit that represents the release.
-      # The commit that represents the release is created in this step and shall only contain the changelog change from UNRELEASED to unstable.
+      - name: Collect source package metadata
+        id: metadata
+        run: |
+          cd package-repo
+          echo "srcpkg_name=$(dpkg-parsechangelog --show-field Source)" >> "$GITHUB_OUTPUT"
+
       - name: Changelog suite name change
         id: changelog
         env:
@@ -107,7 +254,6 @@ jobs:
           echo "Initial changelog content:"
           cat debian/changelog | sed 's/^/\x1b[34m/' | sed 's/$/\x1b[0m/'
 
-          # Check if the latest changelog entry suite is UNRELEASED
           if ! head -1 debian/changelog | grep -q 'UNRELEASED'; then
             echo "Error: The suite in the latest changelog entry is not UNRELEASED." \
                  "The release process expects the latest entry to be UNRELEASED at any point except in the commit (this one) that represents the release"
@@ -115,10 +261,9 @@ jobs:
           fi
 
           version=$(dpkg-parsechangelog --show-field Version)
-          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "Releasing version: ${version} for suite 'unstable'" | sed 's/^/\x1b[32m/' | sed 's/$/\x1b[0m/'
 
-          # This is the important part; change UNRELEASED to unstable and update the changelog timestamp
           dch --release --distribution=unstable "Release"
 
           echo "Updated changelog content:"
@@ -143,20 +288,12 @@ jobs:
           cd package-repo
 
           SOURCE=$(grep-dctrl -n -s Source -r '' debian/control | head -n1)
-
-          # Collect all binary package names from debian/control
           ALL_PKGS=$(grep-dctrl -n -s Package -r '' debian/control | sort -u)
-
           ALL_PKGS_JSON=$(printf '%s\n' "$ALL_PKGS" | jq -c -R -s 'split("\n") | map(select(length>0))')
 
-          # Get the nearest reachable <distro-codename>/* tag from inputs.debian-branch.
-          # This tag represents the packaging repository state for this release.
           PACKAGE_REPO_TAG=$(git describe --tags --match "${DISTRO_CODENAME}/*" --abbrev=0 "${DEBIAN_BRANCH}")
 
           if [[ -f "upstream.conf" ]]; then
-            # ── Prebuilt binary package ──────────────────────────────────────────────
-            # No upstream git repo; source is an Artifactory binary tarball.
-            # Read Artifactory metadata from upstream.conf for provenance.
             echo "ℹ️ upstream.conf found — generating provenance for prebuilt binary package"
             source upstream.conf
 
@@ -179,27 +316,13 @@ jobs:
             }
           }
           EOF
-
           else
-            # ── Source package ───────────────────────────────────────────────────────
-            # Upstream is a git repository; resolve the upstream tag and commit.
             echo "ℹ️ No upstream.conf — generating provenance for source package"
 
             NEAREST_UPSTREAM_BRANCH_TAG=$(git describe --tags --match 'upstream/*' --abbrev=0)
             NEAREST_UPSTREAM_COMMIT=$(git rev-list -n 1 "$NEAREST_UPSTREAM_BRANCH_TAG")
             NEAREST_UPSTREAM_TAG=$(git ls-remote --tags "https://github.com/${UPSTREAM_REPO}.git" | \
               awk -v commit="$NEAREST_UPSTREAM_COMMIT" '$1 == commit && $2 ~ /refs\/tags\// { sub("refs/tags/", "", $2); print $2 }' | head -n1)
-
-            #source_pkg_version : The complete version string for this release (e.g. 1.2.3-1)
-            #upstream_type      : The type of upstream source ("source" for git repos)
-            #upstream_repo      : The upstream source repository name in github format (user/repo)
-            #upstream_repo_tag  : The tag in the upstream source repository that was used in the last promotion (e.g. v1.2.3)
-            #upstream_repo_commit : The commit hash in the upstream source repository that corresponds to the upstream_repo_tag
-            #pkg_repo           : The packaging repository name in github format (user/repo)
-            #pkg_repo_tag       : The tag in the packaging repository that corresponds to this release (e.g. noble/1.2.3-1)
-            #pkg_repo_commit    : The commit hash in the packaging repository that corresponds to the pkg_repo_tag
-            #pkg_repo_upstream_tag : The upstream/* tag in the packaging repository that was used for this release (e.g. upstream/v1.2.3)
-            #binary_pkgs        : List of all binary packages produced by this source package
 
             cat > ../build/provenance.json << EOF
           {
@@ -220,7 +343,6 @@ jobs:
             }
           }
           EOF
-
           fi
 
           echo "Content of the provenance file:"
@@ -229,12 +351,10 @@ jobs:
       - name: Build Debian Packages
         uses: ./qcom-build-utils/.github/actions/build_package
         with:
-          distro-codename: ${{inputs.distro-codename}}
+          distro-codename: ${{ inputs.distro-codename }}
           pkg-dir: package-repo
           build-dir: build
 
-      # After the above step that changed the changlog from UNRELEASED to unstable, now create a new changelog entry
-      # that bumps the version for the next development cycle and sets the suite back to UNRELEASED
       - name: Commit changelog suite change
         working-directory: ./package-repo
         env:
@@ -243,7 +363,6 @@ jobs:
         run: |
           version=$(dpkg-parsechangelog --show-field Version)
 
-          # bump Debian revision (last hyphen-separated field), e.g. 1.0.0-1 -> 1.0.0-2
           if [[ "$version" != *-* ]]; then
             echo "Error: version '$version' has no debian revision part" >&2
             exit 1
@@ -260,7 +379,7 @@ jobs:
           rev=$((rev + 1))
           newversion="${upstream}-${rev}"
           echo "Bumped version -> ${newversion}"
-          dch --newversion=${newversion} --distribution=UNRELEASED --controlmaint "Initial commit"
+          dch --newversion="${newversion}" --distribution=UNRELEASED --controlmaint "Initial commit"
 
           git commit -a -m "Initial commit of new version ${newversion}"
 
@@ -269,13 +388,8 @@ jobs:
 
           git log --graph --oneline -n 10 --color=always
 
-      # Push the provenance entry for this release into qualcomm-linux/qcom-distro-artifacts.
-      # The repo is organised as <suite>/provenance.json. If a provenance file already exists for
-      # the suite, the new package entry is merged into it (updating the key if it already exists,
-      # adding it if it is new). A retry loop handles the rare case where two concurrent releases
-      # push to the same suite file at the same time.
       - name: Push provenance to qcom-distro-artifacts
-        if: ${{ inputs.test-run == false }}
+        if: ${{ !inputs.test-run }}
         env:
           GH_PAT: ${{ secrets.PAT }}
           SUITE: ${{ inputs.distro-codename }}
@@ -295,9 +409,6 @@ jobs:
           NEW_PROVENANCE="../build/provenance.json"
 
           if [[ -f "${SUITE_PROVENANCE}" ]]; then
-            # Merge: update the existing package entry or add a new one.
-            # jq '*' performs a shallow object merge, so each top-level source-package key
-            # is either added or replaced with the new release data.
             jq -s --indent 2 '.[0] * .[1]' "${SUITE_PROVENANCE}" "${NEW_PROVENANCE}" > /tmp/merged_provenance.json
             mv /tmp/merged_provenance.json "${SUITE_PROVENANCE}"
           else
@@ -313,7 +424,6 @@ jobs:
             VERSION=$(jq -r '.[keys[0]].source_pkg_version' "${NEW_PROVENANCE}")
             git commit -m "provenance: update ${SOURCE_PKG} ${VERSION} for ${SUITE}"
 
-            # Retry up to 3 times to handle concurrent pushes from parallel releases
             for attempt in 1 2 3; do
               git push origin main && break
               echo "Push attempt ${attempt} failed, rebasing and retrying..."
@@ -324,15 +434,13 @@ jobs:
       - name: Prepare build logs for upload
         working-directory: ./build/
         run: |
-          # Remove symlink and rename timestamped .build file to its base name
           BUILD_LINK=$(find . -maxdepth 1 -name "*.build" -type l)
           if [ -n "$BUILD_LINK" ]; then
             BUILD_TARGET=$(readlink "$BUILD_LINK")
             rm "$BUILD_LINK"
             mv "$BUILD_TARGET" "$BUILD_LINK"
           fi
-          
-          # JFrog CLI does not allow colon characters in the properties, so we need to replace them with underscores in the build logs that are used to generate the properties for the upload step
+
           sed -i 's/:/_/g' *.build
 
       - name: Upload build artifacts
@@ -341,9 +449,13 @@ jobs:
           name: build-artifacts
           path: build/
 
-  upload-to-s3:
-    needs: pkg-release
-    runs-on: 'lecore-prd-u2404-arm64-xlrg-od-ephem'
+  ubuntu-upload-to-s3:
+    name: Upload to S3 (Ubuntu)
+    if: ${{ needs.resolve.outputs.family == 'ubuntu' }}
+    needs:
+      - resolve
+      - ubuntu-pkg-release
+    runs-on: lecore-prd-u2404-arm64-xlrg-od-ephem
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -355,9 +467,9 @@ jobs:
         run: |
           OWNER_NAME="${{ github.repository_owner }}"
           REPO_NAME="${{ github.event.repository.name }}"
-          CATEGORY_FOLDER="${{ inputs.test-run == true && 'test' || 'proposed'}}"
+          CATEGORY_FOLDER="${{ inputs.test-run == true && 'test' || 'proposed' }}"
           SUITE_NAME="${{ inputs.distro-codename }}"
-          VERSION_NAME="${{ needs.pkg-release.outputs.complete_version }}"
+          VERSION_NAME="${{ needs.ubuntu-pkg-release.outputs.complete_version }}"
           WORKFLOW_BUILD_ID="${{ github.run_id }}"
           WORKFLOW_RUN_ID="${{ github.run_attempt }}"
 
@@ -371,7 +483,7 @@ jobs:
 
           echo "S3 Bucket Path: ${S3_BUCKET_PATH}"
 
-          echo "S3_BUCKET_PATH=${S3_BUCKET_PATH}" >> $GITHUB_ENV
+          echo "S3_BUCKET_PATH=${S3_BUCKET_PATH}" >> "$GITHUB_ENV"
 
       - name: Upload released debian package to S3
         uses: qualcomm-linux/upload-private-artifact-action@aws
@@ -383,10 +495,44 @@ jobs:
       - name: Notify qcom-distro-images of new release via repository dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{secrets.PAT}}
+          token: ${{ secrets.PAT }}
           repository: qualcomm-linux/qcom-distro-images
           event-type: pkg-repo-release
           client-payload: >-
             {
               "artifact_path":"${{ env.S3_BUCKET_PATH }}"
             }
+
+  finalize:
+    name: Finalize outputs
+    needs:
+      - resolve
+      - debian-build
+      - debian-release
+      - ubuntu-pkg-release
+      - ubuntu-upload-to-s3
+    runs-on: ubuntu-latest
+    outputs:
+      workspace: ${{ steps.select.outputs.workspace }}
+      workspace_url: ${{ steps.select.outputs.workspace_url }}
+      srcpkg_name: ${{ steps.select.outputs.srcpkg_name }}
+      srcpkg_version: ${{ steps.select.outputs.srcpkg_version }}
+      complete_version: ${{ steps.select.outputs.complete_version }}
+    steps:
+      - name: Select workflow outputs
+        id: select
+        shell: bash
+        run: |
+          if [[ "${{ needs.resolve.outputs.family }}" == "debian" ]]; then
+            echo "workspace=${{ needs.debian-build.outputs.workspace }}" >> "$GITHUB_OUTPUT"
+            echo "workspace_url=${{ needs.debian-build.outputs.workspace_url }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_name=${{ needs.debian-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_version=${{ needs.debian-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+            echo "complete_version=${{ needs.debian-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "workspace=" >> "$GITHUB_OUTPUT"
+            echo "workspace_url=" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_name=${{ needs.ubuntu-pkg-release.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_version=${{ needs.ubuntu-pkg-release.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+            echo "complete_version=${{ needs.ubuntu-pkg-release.outputs.complete_version }}" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -71,7 +71,7 @@ permissions:
   packages: read
 
 env:
-  DEBUSINE_ACTION_REF: dev/sbeaudoi
+  DEBUSINE_ACTION_REF: main
 
 jobs:
   resolve:

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -30,6 +30,11 @@ on:
         type: boolean
         default: true
 
+      debusine-parent-workspace:
+        description: Parent Debusine workspace used to create per-run child CI workspaces for Debian builds
+        type: string
+        default: ci
+
     secrets:
       PAT:
         description: Personal Access Token with repo permissions to the packaging repository. Needed to check out and push release git state.
@@ -111,6 +116,7 @@ jobs:
       debian-ref: ${{ inputs.debian-branch }}
       suite: ${{ inputs.suite }}
       release: true
+      debusine-parent-workspace: ${{ inputs.debusine-parent-workspace }}
     secrets:
       DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
       DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -18,7 +18,7 @@ on:
         required: false
         default: debian/qcom-next
 
-      distro-codename:
+      suite:
         description: The distribution codename or Debian suite to build and release for. Ex noble, questing, resolute, trixie, sid
         type: string
         default: noble
@@ -80,7 +80,7 @@ jobs:
         id: resolve
         shell: bash
         env:
-          TARGET_SUITE: ${{ inputs.distro-codename }}
+          TARGET_SUITE: ${{ inputs.suite }}
         run: |
           set -euo pipefail
 
@@ -109,7 +109,7 @@ jobs:
     with:
       qcom-build-utils-ref: ${{ inputs.qcom-build-utils-ref }}
       debian-ref: ${{ inputs.debian-branch }}
-      suite: ${{ inputs.distro-codename }}
+      suite: ${{ inputs.suite }}
       release: true
     secrets:
       DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
@@ -176,7 +176,7 @@ jobs:
           DEBUSINE_TARGET_WORKSPACE: prod
           SRCPKG_NAME: ${{ needs.debian-build.outputs.srcpkg_name }}
           SRCPKG_VERSION: ${{ needs.debian-build.outputs.srcpkg_version }}
-          SUITE: ${{ inputs.distro-codename }}
+          SUITE: ${{ inputs.suite }}
         run: |
           set -euxo pipefail
 
@@ -201,7 +201,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/qualcomm-linux/pkg-builder:${{ inputs.distro-codename }}
+      image: ghcr.io/qualcomm-linux/pkg-builder:${{ inputs.suite }}
       options: --privileged
       credentials:
         username: ${{ github.actor }}
@@ -237,7 +237,7 @@ jobs:
         id: changelog
         env:
           DEBIAN_BRANCH: ${{ inputs.debian-branch }}
-          DISTRO_CODENAME: ${{ inputs.distro-codename }}
+          DISTRO_CODENAME: ${{ inputs.suite }}
           BOT_NAME: ${{ vars.DEB_PKG_BOT_CI_NAME }}
           BOT_EMAIL: ${{ vars.DEB_PKG_BOT_CI_EMAIL }}
         run: |
@@ -277,7 +277,7 @@ jobs:
 
       - name: Create provenance file
         env:
-          DISTRO_CODENAME: ${{ inputs.distro-codename }}
+          DISTRO_CODENAME: ${{ inputs.suite }}
           DEBIAN_BRANCH: ${{ inputs.debian-branch }}
           UPSTREAM_REPO: ${{ vars.UPSTREAM_REPO_GITHUB_NAME }}
           PKG_VERSION: ${{ steps.changelog.outputs.version }}
@@ -351,7 +351,7 @@ jobs:
       - name: Build Debian Packages
         uses: ./qcom-build-utils/.github/actions/build_package
         with:
-          distro-codename: ${{ inputs.distro-codename }}
+          suite: ${{ inputs.suite }}
           pkg-dir: package-repo
           build-dir: build
 
@@ -359,7 +359,7 @@ jobs:
         working-directory: ./package-repo
         env:
           DEBIAN_BRANCH: ${{ inputs.debian-branch }}
-          DISTRO_CODENAME: ${{ inputs.distro-codename }}
+          DISTRO_CODENAME: ${{ inputs.suite }}
         run: |
           version=$(dpkg-parsechangelog --show-field Version)
 
@@ -392,7 +392,7 @@ jobs:
         if: ${{ !inputs.test-run }}
         env:
           GH_PAT: ${{ secrets.PAT }}
-          SUITE: ${{ inputs.distro-codename }}
+          SUITE: ${{ inputs.suite }}
           BOT_NAME: ${{ vars.DEB_PKG_BOT_CI_NAME }}
           BOT_EMAIL: ${{ vars.DEB_PKG_BOT_CI_EMAIL }}
         run: |
@@ -468,7 +468,7 @@ jobs:
           OWNER_NAME="${{ github.repository_owner }}"
           REPO_NAME="${{ github.event.repository.name }}"
           CATEGORY_FOLDER="${{ inputs.test-run == true && 'test' || 'proposed' }}"
-          SUITE_NAME="${{ inputs.distro-codename }}"
+          SUITE_NAME="${{ inputs.suite }}"
           VERSION_NAME="${{ needs.ubuntu-pkg-release.outputs.complete_version }}"
           WORKFLOW_BUILD_ID="${{ github.run_id }}"
           WORKFLOW_RUN_ID="${{ github.run_attempt }}"

--- a/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml
+++ b/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml
@@ -34,8 +34,8 @@ on:
         type: boolean
         default: false
 
-      distro-codename:
-        description: The distribution codename to build for. Ex noble, jammy, etc
+      suite:
+        description: The distribution codename or Debian suite to build for. Ex noble, questing, resolute, trixie, sid, unstable
         type: string
         default: noble
 
@@ -61,7 +61,7 @@ jobs:
 
     container:
       # This docker image is built and published by the qualcomm-linux/docker_deb_build repo CI workflow
-      image: ghcr.io/qualcomm-linux/pkg-builder:${{inputs.distro-codename}}
+      image: ghcr.io/qualcomm-linux/pkg-builder:${{inputs.suite}}
       options: --privileged
       credentials:
         username: ${{ github.actor }}
@@ -183,7 +183,7 @@ jobs:
           # use -b to ignore new version is less than current version. This happens because of the ~pr#
           gbp dch \
             --ignore-branch \
-            --distribution=${{inputs.distro-codename}} \
+            --distribution=${{inputs.suite}} \
             --new-version=${{env.upstream_version}}~pr${{inputs.pr-number}}-${{env.distro_revision}} \
             --dch-opt="-b"
 
@@ -192,7 +192,7 @@ jobs:
       - name: Build Debian Packages
         uses: ./qcom-build-utils/.github/actions/build_package
         with:
-          distro-codename: ${{inputs.distro-codename}}
+          suite: ${{inputs.suite}}
           pkg-dir: package-repo
           build-dir: build-area
           run-lintian: ${{inputs.run-lintian}}
@@ -201,4 +201,4 @@ jobs:
         if: true
         uses: ./qcom-build-utils/.github/actions/abi_checker
         with:
-          distro-codename: ${{inputs.distro-codename}}
+          distro-codename: ${{inputs.suite}}

--- a/.github/workflows/workflows_sync.yml
+++ b/.github/workflows/workflows_sync.yml
@@ -1,0 +1,239 @@
+name: Workflows Sync
+description: |
+  Sync workflows from the ../pkg-workflows/** back to all repositories that used pkg-template as a template.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        type: boolean
+        default: false
+        required: true
+        description: |
+          Tick to confirm creating pull requests to sync workflows from pkg-template to all repositories that used pkg-template as a template.
+          If not ticked, the workflow will not create any pull requests and will simply print the list of repositories that would have been synced.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: pkg-template
+
+      - name: Sync workflows from pkg-template
+        id: sync
+        env:
+          GH_TOKEN: ${{secrets.DEB_PKG_BOT_CI_TOKEN}}
+          ORG: qualcomm-linux
+          BOT_NAME: ${{vars.DEB_PKG_BOT_CI_NAME}}
+          BOT_EMAIL: ${{vars.DEB_PKG_BOT_CI_EMAIL}}
+          BOT_USERNAME: ${{vars.DEB_PKG_BOT_CI_USERNAME}}
+          CONFIRMATION_INPUT: ${{ inputs.confirmation }}
+        run: |
+          # Define explicit list of repositories to exclude
+          EXCLUDE_REPOS=("pkg-template" \
+                         "pkg-example" \
+                         "pkg-oss-staging-repo" \
+                         "pkg-linux-firmware" \
+                         "pkg-camera-service-temp" \
+                         "pkg-gst-plugins-imsdk-temp" \
+                         "pkg-kernel-fedora" \
+                         "pkg-linux-kernel" )
+
+          # Array to store created PR URLs
+          PR_URLS=()
+
+          # Get the list of all repositories that used pkg-template as a template
+          repos=$(gh repo list --limit 9999 $ORG --json name --jq '.[] | select(.name | startswith("pkg-")) | .name')
+
+          echo "List of repositories starting with 'pkg-': $repos"
+
+          # pr-pre-post-merge.yml is checked out locally in pkg-workflows/debian/
+          DEBIAN_LATEST_WORKFLOW_FILE="$(pwd)/pkg-template/.github/pkg-workflows/debian/pr-pre-post-merge.yml"
+          echo "📄 Using pr-pre-post-merge.yml from pkg-workflows/debian/"
+
+          for repo in $repos; do
+            # Skip excluded repositories
+            if [[ " ${EXCLUDE_REPOS[@]} " =~ " ${repo} " ]]; then
+              echo "⏭️ Skipping excluded repository: $repo"
+              continue
+            fi
+
+            echo "🔄 Checking repo: $repo"
+
+            # Check if the bot account has write or admin permissions
+            echo "  🔍 Checking permissions for $BOT_USERNAME on $repo"
+            permission_response=$(gh api repos/$ORG/$repo/collaborators/$BOT_USERNAME/permission 2>/dev/null || echo "")
+
+            if [[ -z "$permission_response" ]]; then
+              echo "    ⛔ Cannot verify permissions for $BOT_USERNAME on $repo - skipping"
+              continue
+            fi
+
+            permission_level=$(echo "$permission_response" | jq -r '.permission')
+
+            if [[ "$permission_level" != "admin" && "$permission_level" != "write" ]]; then
+              echo "    ⛔ $BOT_USERNAME does not have write/admin permissions on $repo (has: $permission_level) - skipping"
+              continue
+            fi
+
+            echo "  ✅ $BOT_USERNAME has $permission_level permissions on $repo"
+
+            # Clone the target repository
+            gh repo clone "$ORG/$repo" "$repo" 2>&1 | sed 's/^/  /'
+            cd "$repo"
+
+            # Detect the default branch (usually 'main' but some repos use 'master')
+            default_branch=$(gh api repos/$ORG/$repo --jq '.default_branch')
+            echo "  🌿 Default branch for $repo: $default_branch"
+
+            # Configure git to use gh CLI for authentication
+            gh auth setup-git
+            git config user.name "$BOT_NAME"
+            git config user.email "$BOT_EMAIL"
+
+            # Delete the sync branch if it exists from a previous run
+            if git ls-remote --exit-code --heads origin sync/pkg-template-workflows > /dev/null 2>&1; then
+              echo "    🧹 Deleting existing sync/pkg-template-workflows branch from remote"
+              git push origin --delete sync/pkg-template-workflows 2>&1 | sed 's/^/    /'
+            fi
+
+            # Track if changes are needed
+            isDirty=false
+
+            # Special case: Remove workflows_sync.yml if it exists in target repo
+            if [[ -f ".github/workflows/workflows_sync.yml" ]]; then
+              echo "    🗑️  Removing workflows_sync.yml (should not exist in templated repos)"
+              rm ".github/workflows/workflows_sync.yml"
+              isDirty=true
+            fi
+
+            # Compare and sync workflow files
+            for workflow in ../pkg-template/.github/pkg-workflows/main/*.yml; do
+              workflow_name=$(basename "$workflow")
+
+              target_workflow=".github/workflows/$workflow_name"
+
+              if [[ -f "$target_workflow" ]]; then
+                if diff -q "$workflow" "$target_workflow" > /dev/null; then
+                  echo "    ✅ $workflow_name is up to date"
+                else
+                  echo "    ❌ $workflow_name differs from template"
+                  cp "$workflow" "$target_workflow"
+                  isDirty=true
+                fi
+              else
+                echo "    + Creating $workflow_name (missing from $repo)"
+                mkdir -p ".github/workflows"
+                cp "$workflow" "$target_workflow"
+                isDirty=true
+              fi
+            done
+
+              # Create branch, commit, and push main branch changes if needed
+              if [[ "$isDirty" == "true" ]]; then
+                echo "    📝 Creating branch and committing main branch changes"
+                git checkout -b sync/pkg-template-workflows 2>&1 | sed 's/^/    /'
+                git add .github/workflows/
+                git commit -s -m "chore: sync workflows from pkg-template" 2>&1 | sed 's/^/    /'
+
+                if [[ "$CONFIRMATION_INPUT" == "true" ]]; then
+                  echo "    🚀 Pushing changes and creating PR for $default_branch"
+                  git push origin sync/pkg-template-workflows 2>&1 | sed 's/^/    /'
+
+                  pr_url=$(gh pr create --repo "$ORG/$repo" \
+                    --title "chore: sync workflows from pkg-template" \
+                    --body "This PR syncs the latest workflows from pkg-template." \
+                    --head sync/pkg-template-workflows \
+                    --base "$default_branch")
+
+                  PR_URLS+=("$pr_url")
+                  echo "    ✅ PR created: $pr_url"
+                else
+                  echo "    👀 Dry-run mode - No PR will be created for $default_branch"
+                fi
+
+                # Return to default branch before debian/* sync
+                git checkout "$default_branch" 2>&1 | sed 's/^/    /'
+              else
+                echo "    ✨ No main branch changes needed for $repo"
+              fi
+
+              # Sync pr-pre-post-merge.yml from pkg-template's debian/latest to every debian/* and qcom/debian/* branch
+              debian_branches=$(git branch -r | grep -E 'origin/(qcom/)?debian/' | sed 's|.*origin/||' | tr -d ' ')
+
+              for debian_branch in $debian_branches; do
+                # Skip debian/latest itself (it's the source)
+                if [[ "$debian_branch" == "debian/latest" ]]; then
+                  continue
+                fi
+
+                echo "  🌿 Checking pr-pre-post-merge.yml on branch: $debian_branch"
+                safe_branch_name="${debian_branch//\//-}"
+                debian_sync_branch="sync/pkg-template-pr-merge-${safe_branch_name}"
+
+                # Delete existing sync branch if from a previous run
+                if git ls-remote --exit-code --heads origin "$debian_sync_branch" > /dev/null 2>&1; then
+                  echo "    🧹 Deleting existing $debian_sync_branch"
+                  git push origin --delete "$debian_sync_branch" 2>&1 | sed 's/^/    /'
+                fi
+
+                git checkout "$debian_branch" 2>&1 | sed 's/^/    /'
+
+                isDebianDirty=false
+                if [[ -f ".github/workflows/pr-pre-post-merge.yml" ]]; then
+                  if diff -q "$DEBIAN_LATEST_WORKFLOW_FILE" ".github/workflows/pr-pre-post-merge.yml" > /dev/null; then
+                    echo "    ✅ pr-pre-post-merge.yml is up to date on $debian_branch"
+                  else
+                    echo "    ❌ pr-pre-post-merge.yml differs on $debian_branch"
+                    cp "$DEBIAN_LATEST_WORKFLOW_FILE" ".github/workflows/pr-pre-post-merge.yml"
+                    isDebianDirty=true
+                  fi
+                else
+                  echo "    + Creating pr-pre-post-merge.yml on $debian_branch (missing)"
+                  mkdir -p ".github/workflows"
+                  cp "$DEBIAN_LATEST_WORKFLOW_FILE" ".github/workflows/pr-pre-post-merge.yml"
+                  isDebianDirty=true
+                fi
+
+                if [[ "$isDebianDirty" == "true" ]]; then
+                  git checkout -b "$debian_sync_branch" 2>&1 | sed 's/^/    /'
+                  git add .github/workflows/pr-pre-post-merge.yml
+                  git commit -s -m "chore: sync pr-pre-post-merge.yml from pkg-template debian/latest" 2>&1 | sed 's/^/    /'
+
+                  if [[ "$CONFIRMATION_INPUT" == "true" ]]; then
+                    echo "    🚀 Pushing changes and creating PR for $debian_branch"
+                    git push origin "$debian_sync_branch" 2>&1 | sed 's/^/    /'
+
+                    pr_url=$(gh pr create --repo "$ORG/$repo" \
+                      --title "chore: sync pr-pre-post-merge.yml from pkg-template debian/latest" \
+                      --body "This PR syncs \`pr-pre-post-merge.yml\` from the \`debian/latest\` branch of pkg-template." \
+                      --head "$debian_sync_branch" \
+                      --base "$debian_branch")
+
+                    PR_URLS+=("$pr_url")
+                    echo "    ✅ PR created: $pr_url"
+                  else
+                    echo "    👀 Dry-run mode - No PR will be created for $debian_branch"
+                  fi
+                fi
+              done
+
+            cd ..
+          done
+
+          # Output summary of created PRs
+          if [[ "${#PR_URLS[@]}" -gt 0 ]]; then
+            echo "🎉 Created PRs for the following repositories:"
+            for pr_url in "${PR_URLS[@]}"; do
+              echo "  - $pr_url"
+            done
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,52 +2,45 @@
 
 ## Purpose
 
-`qcom-build-utils` is the shared workflow and helper repository for Qualcomm Linux package repos.
-It owns the reusable GitHub workflows that package repositories call, plus the local helper scripts
-those workflows need for source-package preparation, installability testing, release git handling,
-and other packaging automation.
+`qcom-build-utils` is the shared workflow repository for Qualcomm Linux package repos.
+It owns the reusable GitHub workflows that package repositories call, plus the package-policy
+orchestration around build, test, promotion, and release flows.
 
-## Current Debusine Architecture
+## Current Build/Release Architecture
 
 - Package repos call `qcom-build-pkg-reusable-workflow.yml` and `qcom-release-reusable-workflow.yml`.
-- Those workflows now use `qualcomm-linux/debusine-action` for Debusine-specific operations such as:
-  - importing the `.dsc` artifact
-  - starting Debusine workflows
-- `qcom-build-utils` still owns the local orchestration around that:
-  - generating the source package
-  - preparing the Debusine child workspace and pipeline inputs
-  - polling Debusine work requests with richer diagnostics
-  - validating installability from the Debusine CI workspace
-  - preparing/pushing release git state
-- The Debusine builder images (`ghcr.io/qualcomm-linux/debusine-pkg-builder:<suite>`) are consumed
-  here, but are published from `qualcomm-linux/debusine-action`, not from this repository.
+- Those workflows are now **hybrid**:
+  - Debian suites (`trixie`, `sid`, `unstable`, `bookworm`, `forky`) use
+    `qualcomm-linux/debusine-action` and Debusine builder images
+  - Ubuntu codenames (`noble`, `questing`, `resolute`, and similar Ubuntu targets) use the
+    older local `pkg-builder` path with qcom-build-utils composite actions
+- Debian-path helper entrypoints come from checked-out `debusine-action/lib/`:
+  - `prepare-release`
+  - `generate-source-package`
+  - `build`
+  - `generate-apt-config`
+  - `release`
+  - `push-release`
+- The Debian Debusine builder images (`ghcr.io/qualcomm-linux/debusine-pkg-builder:<suite>`) are
+  published from `qualcomm-linux/debusine-action`, while the Ubuntu-capable `pkg-builder` images
+  are still consumed from GHCR by the local path.
 
 ## Important Workflows
 
 - `.github/workflows/qcom-build-pkg-reusable-workflow.yml`
-  - main package build/test entrypoint for package repos
+  - main hybrid package build/test entrypoint for package repos
 - `.github/workflows/qcom-release-reusable-workflow.yml`
-  - release entrypoint built on top of the Debusine build/test path
+  - hybrid release entrypoint: Debian via Debusine, Ubuntu via pkg-builder + S3 flow
 - `.github/workflows/qcom-promote-upstream-reusable-workflow.yml`
   - upstream-to-packaging promotion flow
 - `.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml`
   - validate upstream PRs against the Debian packaging build
 
-## Important Helper Scripts
+## Important Debian/Debusine Helper Entrypoints
 
-The `scripts/ci/` directory is still active. Do not remove or bypass these without checking call
-sites in the reusable workflows:
-
-- `generate-source-package`
-- `prepare-release`
-- `prepare-debusine-build`
-- `poll-debusine-workflow`
-- `prepare-test`
-- `prepare-debusine-release`
-- `push-release`
-- `generate-apt-config`
-- `next_qcom_version`, `next_qcom_version.py`, `next_qcom_version_test.py`
-- `poll_workflow.py`
+The Debian branch of the reusable workflows depends on the checked-out `debusine-action/lib/`
+scripts. If you change those interfaces, update both the `debusine-action` repo and the workflow
+call sites here.
 
 ## Do Not Reintroduce
 
@@ -56,25 +49,24 @@ clear design change:
 
 - local Debusine wrapper workflows such as `qcom-debusine-reusable-workflow.yml`
 - local Debusine image publishing workflows and `Dockerfiles/debusine-builder/`
+- the copied `scripts/ci/` Debusine helper tree
 - stale `*.old` workflow snapshots
-- unused Incus-era helpers such as `scripts/ci/build`, `scripts/ci/prepare-debusine`, and
-  `scripts/ci/release`
 
 ## Editing Guidance
 
 - Prefer keeping package-repo callers thin; put shared behavior in the reusable workflows here.
 - Keep Debusine-specific implementation inside `debusine-action` unless `qcom-build-utils` truly
-  needs local orchestration around it.
-- Before deleting anything under `scripts/ci/`, search for live references from workflows first.
+  needs local orchestration around it, but preserve the local `pkg-builder` flow for Ubuntu suites.
 - When changing workflow contracts, check the synced package-repo templates and `pkg-example`.
 - Preserve the current split of responsibilities:
   - `qcom-build-utils` orchestrates package-repo behavior
-  - `debusine-action` owns Debusine action logic and builder-image publication
+  - `debusine-action` owns Debusine helper scripts, action logic, and builder-image publication
 
 ## Validation Expectations
 
-For changes that touch the active Debusine build/release path:
+For changes that touch the active hybrid build/release path:
 
 1. validate the edited scripts and workflow YAML locally
 2. push the relevant branch if needed
-3. confirm behavior with an end-to-end `pkg-example` run
+3. confirm the Debian path with an end-to-end `pkg-example` run
+4. confirm the Ubuntu path with a representative pkg-builder-based run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,113 +2,79 @@
 
 ## Purpose
 
-`qcom-build-utils` is the shared CI/CD backbone for Qualcomm Linux Debian packaging.
-It centralizes reusable GitHub workflows, composite actions, and helper scripts used by
-many external repositories (especially `pkg-*` repos and upstream source repos).
+`qcom-build-utils` is the shared workflow and helper repository for Qualcomm Linux package repos.
+It owns the reusable GitHub workflows that package repositories call, plus the local helper scripts
+those workflows need for source-package preparation, installability testing, release git handling,
+and other packaging automation.
 
-When editing this repository, optimize for:
+## Current Debusine Architecture
 
-- interface stability,
-- backward compatibility,
-- minimal and reviewable diffs,
-- docs that stay in sync with behavior.
+- Package repos call `qcom-build-pkg-reusable-workflow.yml` and `qcom-release-reusable-workflow.yml`.
+- Those workflows now use `qualcomm-linux/debusine-action` for Debusine-specific operations such as:
+  - importing the `.dsc` artifact
+  - starting Debusine workflows
+- `qcom-build-utils` still owns the local orchestration around that:
+  - generating the source package
+  - preparing the Debusine child workspace and pipeline inputs
+  - polling Debusine work requests with richer diagnostics
+  - validating installability from the Debusine CI workspace
+  - preparing/pushing release git state
+- The Debusine builder images (`ghcr.io/qualcomm-linux/debusine-pkg-builder:<suite>`) are consumed
+  here, but are published from `qualcomm-linux/debusine-action`, not from this repository.
 
-## Repository Layout
+## Important Workflows
 
-- `.github/workflows/`: reusable workflows called via `workflow_call`
-- `.github/actions/`: composite actions used by reusable workflows
-- `scripts/`: Python and shell helpers (ABI/APT/promotion helpers)
-- `kernel/scripts/`: kernel image and `.deb` build scripts
-- `bootloader/`: EFI/ESP image build script
-- `rootfs/scripts/`: rootfs build script
-- `docs/`: workflow/action/integration documentation
+- `.github/workflows/qcom-build-pkg-reusable-workflow.yml`
+  - main package build/test entrypoint for package repos
+- `.github/workflows/qcom-release-reusable-workflow.yml`
+  - release entrypoint built on top of the Debusine build/test path
+- `.github/workflows/qcom-promote-upstream-reusable-workflow.yml`
+  - upstream-to-packaging promotion flow
+- `.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml`
+  - validate upstream PRs against the Debian packaging build
 
-## Treat These as Public Interfaces
+## Important Helper Scripts
 
-Changes in these paths can affect many downstream repos and should be handled carefully:
+The `scripts/ci/` directory is still active. Do not remove or bypass these without checking call
+sites in the reusable workflows:
 
-- `.github/workflows/*.yml`
-- `.github/actions/*/action.yml`
-- `scripts/deb_abi_checker.py`
-- `scripts/ppa_interface.py`
-- `scripts/ppa_organizer.py`
-- `scripts/merge_debian_packaging_upstream`
+- `generate-source-package`
+- `prepare-release`
+- `prepare-debusine-build`
+- `poll-debusine-workflow`
+- `prepare-test`
+- `prepare-debusine-release`
+- `push-release`
+- `generate-apt-config`
+- `next_qcom_version`, `next_qcom_version.py`, `next_qcom_version_test.py`
+- `poll_workflow.py`
 
-For interface paths above, avoid breaking changes unless the request explicitly calls for one.
+## Do Not Reintroduce
 
-## Working Rules for Agents
+These older Debusine-era artifacts were intentionally removed and should stay gone unless there is a
+clear design change:
 
-1. Keep scope tight to the user request; avoid opportunistic refactors.
-2. Preserve existing workflow/action inputs, outputs, secrets, and env names when possible.
-3. Prefer additive changes over renames/removals for workflow contracts.
-4. Keep shell/YAML changes easy to diff; avoid reformatting unrelated blocks.
-5. If behavior changes, update docs in the same change set.
-6. Call out compatibility impact explicitly in your handoff.
+- local Debusine wrapper workflows such as `qcom-debusine-reusable-workflow.yml`
+- local Debusine image publishing workflows and `Dockerfiles/debusine-builder/`
+- stale `*.old` workflow snapshots
+- unused Incus-era helpers such as `scripts/ci/build`, `scripts/ci/prepare-debusine`, and
+  `scripts/ci/release`
 
-## Workflow & Action Conventions
+## Editing Guidance
 
-- Reusable workflows are consumed through `workflow_call`; input names are contract surface.
-- Most package builds are ARM64-targeted and run in `ghcr.io/qualcomm-linux/pkg-builder:*` containers.
-- `build_package` supports both source and prebuilt modes (via `upstream.conf`); maintain both paths.
-- Source builds rely on Debian packaging conventions (`debian/changelog`, `gbp`, `sbuild`).
-- Promotion/release workflows rely on branch/tag naming patterns (`debian/*`, `upstream/*`, `<distro>/<version>`).
+- Prefer keeping package-repo callers thin; put shared behavior in the reusable workflows here.
+- Keep Debusine-specific implementation inside `debusine-action` unless `qcom-build-utils` truly
+  needs local orchestration around it.
+- Before deleting anything under `scripts/ci/`, search for live references from workflows first.
+- When changing workflow contracts, check the synced package-repo templates and `pkg-example`.
+- Preserve the current split of responsibilities:
+  - `qcom-build-utils` orchestrates package-repo behavior
+  - `debusine-action` owns Debusine action logic and builder-image publication
 
-## Script Conventions
+## Validation Expectations
 
-### Python (`scripts/*.py`)
+For changes that touch the active Debusine build/release path:
 
-- Keep existing CLI flags/defaults stable unless explicitly requested.
-- Preserve return/exit semantics where consumers may depend on them.
-- For ABI checker work, preserve bitmask meanings in `deb_abi_checker.py`.
-- Keep logging actionable and consistent with `color_logger` patterns.
-
-### Shell (`scripts/*`, `kernel/scripts/*`, `bootloader/*`, `rootfs/scripts/*`)
-
-- Keep scripts fail-fast with clear error text.
-- Preserve required environment variable names and command-line interfaces.
-- Avoid introducing bash-specific features into scripts that are intended to be portable unless already bash-based.
-
-## Documentation Sync Expectations
-
-When functionality changes, update matching docs:
-
-- Reusable workflows: `docs/reusable-workflows.md`
-- Composite actions: `docs/github-actions.md` and `docs/actions/*.md`
-- High-level behavior/integration: `README.md`, `docs/workflow-architecture.md`, `docs/package-repo-integration.md`
-- Script CLI behavior: `scripts/README.md`
-
-If docs are intentionally deferred, state that clearly in the final handoff.
-
-## Validation Checklist
-
-Run the smallest relevant checks for touched files:
-
-- YAML/workflow/action edits:
-  - verify syntax/indentation,
-  - verify referenced input/secret/env names stay consistent.
-- Python edits:
-  - `python3 -m py_compile scripts/*.py`
-- Shell edits:
-  - `bash -n <script>` for each modified shell script.
-- Docs-only edits:
-  - verify file paths, workflow/action names, and examples remain accurate.
-
-If end-to-end CI cannot be run locally, explicitly list what was validated and what remains unverified.
-
-## Common Pitfalls
-
-- Breaking reusable workflow inputs consumed by external repositories.
-- Modifying ABI checker return semantics without coordinating consumers.
-- Updating behavior but leaving docs/examples stale.
-- Assuming x86-only behavior in ARM64-targeted workflow paths.
-- Mixing unrelated cleanups into contract-sensitive files.
-
-## PR/Change Handoff Guidance
-
-When handing off changes, include:
-
-- what interface (if any) changed,
-- downstream impact/risk,
-- validation performed,
-- any required repository variables/secrets relevant to the change
-  (for example `PKG_REPO_GITHUB_NAME`, `UPSTREAM_REPO_GITHUB_NAME`, PAT/token expectations).
+1. validate the edited scripts and workflow YAML locally
+2. push the relevant branch if needed
+3. confirm behavior with an end-to-end `pkg-example` run

--- a/README.md
+++ b/README.md
@@ -71,11 +71,21 @@ Package repositories call these workflows from their own `.github/workflows/` di
 
 | Workflow | Purpose |
 |----------|---------|
-| **qcom-build-pkg-reusable-workflow** | Main Debian package build — used for both pre-merge (PR) and post-merge builds. Orchestrates build, ABI check, and repository push. |
+| **qcom-build-pkg-reusable-workflow** | Main package build workflow — routes Debian suites through Debusine and Ubuntu codenames through the local pkg-builder path. |
 | **qcom-promote-upstream-reusable-workflow** | Promotes a new upstream release into a package repo — merges upstream code, updates changelog, and creates a PR. |
 | **qcom-upstream-pr-pkg-build-reusable-workflow** | Validates that PRs in an upstream repo won't break the Debian package build. Called from the upstream repo. |
-| **qcom-release-reusable-workflow** | Triggers a formal release — finalizes the changelog, builds packages, uploads to S3, and notifies downstream consumers. |
+| **qcom-release-reusable-workflow** | Triggers a formal release — Debian suites use Debusine publish, Ubuntu codenames keep the local pkg-builder/S3 release path. |
 | **qcom-preflight-checks** | Security and quality gates — runs repolinter, semgrep, license checks, and dependency review. |
+
+## Builder Images
+
+`qcom-build-utils` consumes two image families:
+
+- `ghcr.io/qualcomm-linux/debusine-pkg-builder:{suite}` for Debian suites routed through Debusine
+- `ghcr.io/qualcomm-linux/pkg-builder:{codename}` for Ubuntu codenames routed through the local build path
+
+The Debusine-specific helper scripts used by the Debian path are checked out from
+`qualcomm-linux/debusine-action` at runtime.
 
 ## Composite Actions
 
@@ -132,9 +142,9 @@ See [pkg-example](https://github.com/qualcomm-linux/pkg-example) for a complete 
 
 | Component | Details |
 |-----------|---------|
-| **Container images** | `ghcr.io/qualcomm-linux/pkg-builder:{arch}-{distro}` — pre-built for `arm64`/`amd64` across `noble`, `questing`, `resolute`, `trixie`, `sid` |
+| **Container images** | `ghcr.io/qualcomm-linux/debusine-pkg-builder:{suite}` for Debian/Debusine execution and `ghcr.io/qualcomm-linux/pkg-builder:{codename}` for Ubuntu/pkg-builder execution |
 | **Staging APT repo** | [pkg-oss-staging-repo](https://github.com/qualcomm-linux/pkg-oss-staging-repo) served via GitHub Pages |
-| **Runners** | Self-hosted ARM64 runners (`lecore-prd-u2404-arm64-xlrg-od-ephem`) |
+| **Runners** | `ubuntu-latest` for the Debian Debusine path and ARM pkg-builder runners for the local Ubuntu build/release path |
 | **Artifact storage** | S3 for release builds |
 
 ## Build & Utility Scripts

--- a/docs/actions/build_package.md
+++ b/docs/actions/build_package.md
@@ -8,7 +8,7 @@
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `distro-codename` | Yes | - | Ubuntu distribution codename (noble, questing, jammy, etc.) |
+| `suite` | Yes | - | Distribution codename or Debian suite (noble, questing, trixie, etc.) |
 | `pkg-dir` | Yes | - | Directory containing the Debian package source |
 | `build-dir` | Yes | - | Directory where build artifacts will be placed |
 | `run-lintian` | No | `false` | Whether to run lintian quality checks |
@@ -57,7 +57,7 @@ gbp buildpackage \
   --git-ignore-branch \
   --git-builder="sbuild --host=arm64 \
                         --build=${BUILD_ARCH} \
-                        --dist=${distro-codename} \
+                        --dist=${suite} \
                         ${lintian_flag} \
                         --build-dir ../${build-dir} \
                         --build-dep-resolver=apt \
@@ -91,7 +91,7 @@ After successful build, the following artifacts are created in `build-dir`:
 - name: Build Debian Package
   uses: ./qcom-build-utils/.github/actions/build_package
   with:
-    distro-codename: noble
+    suite: noble
     pkg-dir: package-repo
     build-dir: build-area
     run-lintian: true

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -28,11 +28,17 @@ The qcom-build-utils repository provides four main composite actions:
 
 ### Action Location
 
-All actions are referenced relative to the qcom-build-utils checkout:
+Composite actions are referenced relative to the qcom-build-utils checkout:
 
 ```yaml
 uses: ./qcom-build-utils/.github/actions/{action_name}
 ```
+
+The reusable build/release workflows are hybrid:
+
+- Debian suites check out `qualcomm-linux/debusine-action` and invoke its `lib/`
+  helper scripts directly
+- Ubuntu codenames keep using the local `pkg-builder` + composite-action path
 
 ### Error Handling
 

--- a/docs/package-repo-integration.md
+++ b/docs/package-repo-integration.md
@@ -245,6 +245,23 @@ jobs:
       is-post-merge: true
 ```
 
+#### Hybrid release caller
+
+The release caller remains a thin package-repo entrypoint that invokes the
+`qcom-build-utils` reusable workflow directly, while the suite-family routing
+stays encapsulated inside `qcom-build-utils`.
+
+For Debian suites, it uses a separate secret model from the build callers:
+
+- `DEBUSINE_TOKEN`: repository or organization secret for CI workspace build/test access
+- `DEBUSINE_RELEASE_TOKEN`: separate repository or organization secret used only for the final Debusine prod publish step
+
+Package repositories pass `DEBUSINE_RELEASE_TOKEN` directly to
+`qcom-release-reusable-workflow.yml` as a named secret so the reusable workflow
+can publish the successful Debusine CI workspace and push the release git state
+without expanding the caller workflow. Ubuntu releases keep using the older
+local `pkg-builder` + S3 path and do not use those Debusine secrets.
+
 #### Step 4: Initial Commit
 
 > **Note**: If you created your repository from pkg-template, the initial structure is already in place. You should customize the files and then commit your changes.

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -9,9 +9,9 @@ Reusable workflows are defined in `.github/workflows/` and are designed to be ca
 ## Available Workflows
 
 1. [qcom-build-pkg-reusable-workflow](#qcom-build-pkg-reusable-workflow)
-2. [qcom-promote-upstream-reusable-workflow](#qcom-promote-upstream-reusable-workflow)
-3. [qcom-upstream-pr-pkg-build-reusable-workflow](#qcom-upstream-pr-pkg-build-reusable-workflow)
-4. [qcom-container-build-and-upload](#qcom-container-build-and-upload)
+2. [qcom-release-reusable-workflow](#qcom-release-reusable-workflow)
+3. [qcom-promote-upstream-reusable-workflow](#qcom-promote-upstream-reusable-workflow)
+4. [qcom-upstream-pr-pkg-build-reusable-workflow](#qcom-upstream-pr-pkg-build-reusable-workflow)
 5. [qcom-preflight-checks](#qcom-preflight-checks)
 
 ---
@@ -20,25 +20,20 @@ Reusable workflows are defined in `.github/workflows/` and are designed to be ca
 
 **File**: `.github/workflows/qcom-build-pkg-reusable-workflow.yml`
 
-**Purpose**: The main workflow for building Debian packages from package repositories. This workflow is called by both pre-merge and post-merge workflows in package repositories.
+**Purpose**: Build a package through a hybrid flow: Debian suites are built and tested through Debusine, while Ubuntu codenames keep using the local `pkg-builder` + composite-action path.
 
 ### Workflow Diagram
 
 ```mermaid
 flowchart TD
-    A[Workflow Called] --> B[Checkout qcom-build-utils]
-    B --> C[Checkout Package Repository]
-    C --> D[Build Debian Package<br/>build_package action]
-    D --> E{run-abi-checker?}
-    E -->|Yes| F[Run ABI Checker<br/>abi_checker action]
-    E -->|No| G{push-to-repo?}
-    F --> G
-    G -->|Yes| H[Push to Repository<br/>push_to_repo action]
-    G -->|No| I{is-post-merge?}
-    H --> I
-    I -->|Yes| J[Create debian/version tag]
-    I -->|No| K[End]
-    J --> K
+    A[Workflow Called] --> B[Resolve suite family]
+    B -->|Debian| C[Checkout debusine-action helpers]
+    C --> D[Generate source package + build in Debusine]
+    D --> E[Test installability from Debusine workspace]
+    B -->|Ubuntu| F[Run local pkg-builder build]
+    F --> G[Optional ABI check]
+    E --> H[Expose outputs]
+    G --> H
 ```
 
 ### Inputs
@@ -46,45 +41,42 @@ flowchart TD
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `qcom-build-utils-ref` | string | Yes | - | The ref (branch/tag) of qcom-build-utils to use |
-| `debian-ref` | string | Yes | `debian/qcom-next` | The debian branch/tag to build |
-| `distro-codename` | string | No | `noble` | Ubuntu distribution codename (noble, jammy, questing, etc.) |
-| `run-lintian` | boolean | No | `false` | Whether to run lintian during build |
-| `run-abi-checker` | boolean | No | `false` | Whether to check ABI compatibility |
-| `push-to-repo` | boolean | No | `false` | Whether to push built package to repository |
-| `is-post-merge` | boolean | No | `false` | True if triggered by merge to debian/qcom-next |
-| `runner` | string | No | `lecore-prd-u2404-arm64-xlrg-od-ephem` | GitHub runner to use |
+| `debian-ref` | string | Yes | `debian/qcom-next` | The package-repository ref to check out and build |
+| `suite` | string | No | `""` | Preferred modern input for the distribution codename or Debian suite |
+| `distro-codename` | string | No | `""` | Backward-compatible alias for older callers |
+| `run-lintian` | boolean | No | `true` | Used by the Ubuntu/pkg-builder path |
+| `run-abi-checker` | boolean | No | `false` | Used by the Ubuntu/pkg-builder path |
+| `is-prebuilt` | string | No | `""` | Passed through to the Ubuntu/pkg-builder `build_package` action |
+| `job-index` | string | No | `"0"` | Optional matrix index used to keep Debusine child workspace names unique |
+| `release` | boolean | No | `false` | Whether to prepare the release bundle before generating the Debian release source package |
 
-### Environment Variables
+### Secrets
 
-- `REPO_URL`: `https://qualcomm-linux.github.io/pkg-oss-staging-repo/`
-- `REPO_NAME`: `qualcomm-linux/pkg-oss-staging-repo`
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `DEBUSINE_USER` | Debian only | Debusine user used by the Debian test gate |
+| `DEBUSINE_TOKEN` | Debian only | Debusine token used to create the child workspace and submit the Debian source package |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `target_suite` | The resolved suite/codename actually used by the workflow |
+| `workspace` | Debusine child workspace name |
+| `workspace_url` | Debusine web URL for that child workspace |
+| `srcpkg_name` | Source package name |
+| `srcpkg_version` | Source package version |
 
 ### Workflow Steps
 
-1. **Checkout qcom-build-utils**: Sparse checkout of `.github` and `scripts` directories
-2. **Checkout Package Repository**: Full checkout with tags for version information
-3. **Build Debian Package**: Uses `build_package` composite action
-4. **Run ABI Checker** (conditional): Compares ABI with repository version
-5. **Push to Repository** (conditional): Uploads package to staging repository
-6. **Tag Version** (post-merge only): Creates `debian/{version}` git tag
+1. **Resolve suite family**: Normalize the caller input and decide whether the run is Debian or Ubuntu
+2. **Debian path**: Check out `debusine-action/lib`, optionally prepare a release bundle, generate a source package, submit it to Debusine, and run installability checks from the Debusine CI workspace
+3. **Ubuntu path**: Run the old local `pkg-builder` flow with `build_package` and optional `abi_checker`
+4. **Publish Outputs**: Expose consistent source-package metadata; Debusine workspace outputs are populated only for Debian runs
 
 ### Usage Examples
 
-#### Pre-merge (PR) Build
-
-```yaml
-jobs:
-  build:
-    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-build-pkg-reusable-workflow.yml@development
-    with:
-      qcom-build-utils-ref: development
-      debian-ref: ${{github.head_ref}}
-      run-abi-checker: true
-      push-to-repo: false
-      is-post-merge: false
-```
-
-#### Post-merge Build and Publish
+#### Manual build from a packaging ref
 
 ```yaml
 jobs:
@@ -93,9 +85,103 @@ jobs:
     with:
       qcom-build-utils-ref: development
       debian-ref: debian/qcom-next
-      push-to-repo: true
-      run-abi-checker: true
-      is-post-merge: true
+      suite: trixie
+```
+
+#### Matrix-safe caller
+
+```yaml
+jobs:
+  build-matrix:
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-build-pkg-reusable-workflow.yml@development
+    with:
+      qcom-build-utils-ref: development
+      debian-ref: refs/heads/${{ matrix.target_branch }}
+      suite: ${{ matrix.suite }}
+      job-index: ${{ strategy.job-index }}
+```
+
+This workflow is the low-level build/test primitive used directly by package
+repositories.
+
+---
+
+## qcom-release-reusable-workflow
+
+**File**: `.github/workflows/qcom-release-reusable-workflow.yml`
+
+**Purpose**: Release through a hybrid flow: Debian suites use Debusine build/test/publish, while Ubuntu codenames keep the older local `pkg-builder` + S3 release process.
+
+### Workflow Diagram
+
+```mermaid
+flowchart TD
+    A[Workflow Called] --> B[Resolve suite family]
+    B -->|Debian| C[Prepare release bundle + build/test in Debusine]
+    C --> D{test-run?}
+    D -->|true| E[Stop after validation]
+    D -->|false| F[Publish CI workspace to Debusine prod]
+    F --> G[Push release tag and reopen development]
+    B -->|Ubuntu| H[Run local release/tag/provenance flow]
+    H --> I[Build in pkg-builder]
+    I --> J[Upload artifacts to S3]
+```
+
+### Inputs
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `qcom-build-utils-ref` | string | Yes | - | The ref (branch/tag) of qcom-build-utils to invoke |
+| `debian-branch` | string | No | `debian/qcom-next` | The packaging branch to release from |
+| `distro-codename` | string | No | `noble` | Distribution codename or Debian suite to build/test/release |
+| `test-run` | boolean | No | `true` | Debian: stop after Debusine build/test. Ubuntu: keep the older release flow and upload to the test S3 location |
+
+### Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `PAT` | Yes | GitHub token used to check out and push the packaging repository |
+| `DEBUSINE_USER` | Debian only | Debusine user used for CI workspace apt access during the Debian test gate |
+| `DEBUSINE_TOKEN` | Debian only | Debusine CI token used for the Debian build workspace and test gate |
+| `DEBUSINE_RELEASE_TOKEN` | Debian publish only | Separate Debusine production token used only for the Debian publish step |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `workspace` | Debusine child workspace name for Debian releases; empty for Ubuntu |
+| `workspace_url` | Debusine web URL for that child workspace for Debian releases; empty for Ubuntu |
+| `srcpkg_name` | Source package name prepared for release |
+| `srcpkg_version` | Source package version prepared for release |
+| `complete_version` | Alias for `srcpkg_version` |
+
+### Workflow Steps
+
+1. **Resolve suite family**: Decide whether the release follows the Debian or Ubuntu branch
+2. **Debian branch**: Reuse `qcom-build-pkg-reusable-workflow` with `release=true`, then optionally publish to Debusine prod and push git state
+3. **Ubuntu branch**: Restore the earlier local release flow with changelog/tag handling, provenance generation, local `pkg-builder` build, and S3 upload
+
+### Caller Requirements
+
+- Debian callers should pass `DEBUSINE_RELEASE_TOKEN` when they want the reusable workflow to publish to Debusine prod
+- Ubuntu callers do not use the Debusine secrets, but still need `PAT` for the release git/S3/dispatch flow
+
+### Usage Example
+
+```yaml
+jobs:
+  release:
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-release-reusable-workflow.yml@development
+    with:
+      qcom-build-utils-ref: development
+      distro-codename: trixie
+      debian-branch: debian/qcom-next
+      test-run: false
+    secrets:
+      PAT: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
+      DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+      DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+      DEBUSINE_RELEASE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}
 ```
 
 ---

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -32,8 +32,9 @@ flowchart TD
     D --> E[Test installability from Debusine workspace]
     B -->|Ubuntu| F[Run local pkg-builder build]
     F --> G[Optional ABI check]
+    G --> I[Test installability from uploaded Ubuntu artifacts]
     E --> H[Expose outputs]
-    G --> H
+    I --> H
 ```
 
 ### Inputs
@@ -71,7 +72,7 @@ flowchart TD
 
 1. **Resolve suite family**: Normalize the caller input and decide whether the run is Debian or Ubuntu
 2. **Debian path**: Check out `debusine-action/lib`, optionally prepare a release bundle, generate a source package, submit it to Debusine under the configured parent workspace, and run installability checks from the resulting Debusine CI workspace
-3. **Ubuntu path**: Run the old local `pkg-builder` flow with `build_package` and optional `abi_checker`
+3. **Ubuntu path**: Run the local `pkg-builder` flow with `build_package`, optional `abi_checker`, upload the produced package set, and validate installability from those artifacts in a fresh Ubuntu test job
 4. **Publish Outputs**: Expose consistent source-package metadata; Debusine workspace outputs are populated only for Debian runs
 
 ### Usage Examples

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -42,8 +42,7 @@ flowchart TD
 |-----------|------|----------|---------|-------------|
 | `qcom-build-utils-ref` | string | Yes | - | The ref (branch/tag) of qcom-build-utils to use |
 | `debian-ref` | string | Yes | `debian/qcom-next` | The package-repository ref to check out and build |
-| `suite` | string | No | `""` | Preferred modern input for the distribution codename or Debian suite |
-| `distro-codename` | string | No | `""` | Backward-compatible alias for older callers |
+| `suite` | string | No | `unstable` | Distribution codename or Debian suite |
 | `run-lintian` | boolean | No | `true` | Used by the Ubuntu/pkg-builder path |
 | `run-abi-checker` | boolean | No | `false` | Used by the Ubuntu/pkg-builder path |
 | `is-prebuilt` | string | No | `""` | Passed through to the Ubuntu/pkg-builder `build_package` action |
@@ -133,7 +132,7 @@ flowchart TD
 |-----------|------|----------|---------|-------------|
 | `qcom-build-utils-ref` | string | Yes | - | The ref (branch/tag) of qcom-build-utils to invoke |
 | `debian-branch` | string | No | `debian/qcom-next` | The packaging branch to release from |
-| `distro-codename` | string | No | `noble` | Distribution codename or Debian suite to build/test/release |
+| `suite` | string | No | `noble` | Distribution codename or Debian suite to build/test/release |
 | `test-run` | boolean | No | `true` | Debian: stop after Debusine build/test. Ubuntu: keep the older release flow and upload to the test S3 location |
 
 ### Secrets
@@ -174,7 +173,7 @@ jobs:
     uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-release-reusable-workflow.yml@development
     with:
       qcom-build-utils-ref: development
-      distro-codename: trixie
+      suite: trixie
       debian-branch: debian/qcom-next
       test-run: false
     secrets:
@@ -310,7 +309,7 @@ flowchart TD
 | `pkg-repo` | string | Yes | - | The package repository to test against |
 | `pr-number` | number | Yes | - | The PR number in upstream repo |
 | `run-lintian` | boolean | No | `false` | Whether to run lintian |
-| `distro-codename` | string | No | `noble` | Distribution codename |
+| `suite` | string | No | `noble` | Distribution codename or Debian suite |
 | `runner` | string | No | `ubuntu-latest` | Runner to use |
 
 ### Environment Variables

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -48,6 +48,7 @@ flowchart TD
 | `is-prebuilt` | string | No | `""` | Passed through to the Ubuntu/pkg-builder `build_package` action |
 | `job-index` | string | No | `"0"` | Optional matrix index used to keep Debusine child workspace names unique |
 | `release` | boolean | No | `false` | Whether to prepare the release bundle before generating the Debian release source package |
+| `debusine-parent-workspace` | string | No | `ci` | Parent Debusine workspace used to create child CI workspaces for Debian builds |
 
 ### Secrets
 
@@ -69,7 +70,7 @@ flowchart TD
 ### Workflow Steps
 
 1. **Resolve suite family**: Normalize the caller input and decide whether the run is Debian or Ubuntu
-2. **Debian path**: Check out `debusine-action/lib`, optionally prepare a release bundle, generate a source package, submit it to Debusine, and run installability checks from the Debusine CI workspace
+2. **Debian path**: Check out `debusine-action/lib`, optionally prepare a release bundle, generate a source package, submit it to Debusine under the configured parent workspace, and run installability checks from the resulting Debusine CI workspace
 3. **Ubuntu path**: Run the old local `pkg-builder` flow with `build_package` and optional `abi_checker`
 4. **Publish Outputs**: Expose consistent source-package metadata; Debusine workspace outputs are populated only for Debian runs
 
@@ -85,6 +86,7 @@ jobs:
       qcom-build-utils-ref: development
       debian-ref: debian/qcom-next
       suite: trixie
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}
 ```
 
 #### Matrix-safe caller
@@ -134,6 +136,7 @@ flowchart TD
 | `debian-branch` | string | No | `debian/qcom-next` | The packaging branch to release from |
 | `suite` | string | No | `noble` | Distribution codename or Debian suite to build/test/release |
 | `test-run` | boolean | No | `true` | Debian: stop after Debusine build/test. Ubuntu: keep the older release flow and upload to the test S3 location |
+| `debusine-parent-workspace` | string | No | `ci` | Parent Debusine workspace passed through to the Debian build/test phase |
 
 ### Secrets
 
@@ -176,6 +179,7 @@ jobs:
       suite: trixie
       debian-branch: debian/qcom-next
       test-run: false
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}
     secrets:
       PAT: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
       DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}


### PR DESCRIPTION
## Summary

Migrate `qcom-build-utils` onto the current Debusine-backed package build,
promote, and release flow, with `debusine-action` owning the Debusine-specific
execution path.

## What changed

- rework the reusable package build workflow around Debusine-backed source
  package staging, Debusine build orchestration, and post-build testing
- add shared post-build testing for Debian and Ubuntu consumers
- switch the package workflow interfaces over to a shared `suite` input shape
- keep reusable workflow callers passing `qcom-build-utils-ref` explicitly
  instead of resolving a workflow SHA from an OIDC token
- make the Debusine parent workspace configurable for downstream repositories
- refresh the promote and release reusable workflows to match the Debusine
  packaging path
- restore the reusable build and release workflows to
  `qualcomm-linux/debusine-action@main` now that PR #25 merged
- add package-repo workflow source files under `.github/pkg-workflows/` and the
  sync automation that copies them into managed package repositories
- update the README and workflow docs to describe the current architecture and
  the ownership split between `qcom-build-utils` and `debusine-action`
- refresh `AGENTS.md` with the current repository guidance

## Commit structure

1. `9783119` — Update repository guidance for AI agents
2. `17b8255` — Integrate Debusine-backed package workflows
3. `bedf9c0` — Use suite across package workflow interfaces
4. `49bcb09` — Make Debusine parent workspace configurable
5. `5a8217e` — Add shared Debian and Ubuntu post-build tests
6. `ea4e8d0` — Use main for release workflow ref

## Validation

### Downstream Debusine workflow path

These changes were exercised end to end during the paired
`debusine-action` review by validating the copied Debusine workflows in
downstream package repos:

- `pkg-example`
  - `Debusine Daily`: success
  - `Debusine Release`: success
  - `Debusine PR Hook`: success
  - `Debusine PR Check`: success
- `pkg-fastrpc`
  - `Debusine Daily`: success
  - `Debusine Release`: success
- `pkg-alsa-ucm-conf`
  - `Debusine Daily`: success
  - `Debusine Release`: success

### Fresh pkg-example canary after ref cleanup

After dropping the temporary `qcom-build-utils` validation ref and restoring
stable `debusine-action@main` refs in the reusable workflows:

- `pkg-example` `Build Debian Package` (`sid`)
  - run: [26114623855](https://github.com/qualcomm-linux/pkg-example/actions/runs/26114623855)
  - Debian Debusine build path succeeded
  - shared `Test` job succeeded against the Debusine workspace artifacts
- `pkg-example` `Build Debian Package` (`noble`)
  - run: [26114626219](https://github.com/qualcomm-linux/pkg-example/actions/runs/26114626219)
  - Ubuntu build path succeeded
  - shared `Test` job succeeded against the Ubuntu build artifacts

### Additional downstream package-build validation

After removing the workflow-SHA/OIDC resolver from `qcom-build-utils`, the
temporary downstream callers that still track `@development` were refreshed to
pass `qcom-build-utils-ref` explicitly again.

With those caller updates in place:

- `pkg-fastrpc` `Build Debian Package`
  - run: [25934426529](https://github.com/qualcomm-linux/pkg-fastrpc/actions/runs/25934426529)
  - reusable workflow starts correctly and reaches the shared `Test` job
  - remaining failure is repo-specific: `fastrpc-support` depends on
    `hexagon-dsp-binaries`, which is not installable in that test environment
- `pkg-alsa-ucm-conf` `Build Debian Package`
  - run: [25934430377](https://github.com/qualcomm-linux/pkg-alsa-ucm-conf/actions/runs/25934430377)
  - reusable workflow starts correctly and reaches the Ubuntu build path
  - remaining failure is repo-specific: `gbp` errors with
    `upstream/1.2.15.3 is not a valid treeish`

These downstream reruns confirmed that the explicit-ref interface is wired
correctly: the remaining failures happen inside repo-specific build/test logic,
not at workflow startup.

## Notes

- `qcom-build-utils` now consumes the Debusine builder images and reusable
  Debusine CI path supplied by `qualcomm-linux/debusine-action` rather than
  maintaining a separate Debusine execution layer here.
- `development` no longer carries validation-only `debusine-action` refs; the
  reusable build and release workflows now point at
  `qualcomm-linux/debusine-action@main`.