### PR TITLE
build-rootfs: keep stable ethernet interface name

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -495,7 +495,7 @@ GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=
 
 # Kernel parameters applied to BOTH Normal and Recovery boot modes
 # (Critical hardware settings: console, rootfs, clocks, EFI)
-GRUB_CMDLINE_LINUX="earlycon console=ttyMSM0,115200n8 root=LABEL=system cma=128M rw clk_ignore_unused pd_ignore_unused rootwait ignore_loglevel"
+GRUB_CMDLINE_LINUX="earlycon console=ttyMSM0,115200n8 root=LABEL=system cma=128M net.ifnames=0 rw clk_ignore_unused pd_ignore_unused rootwait ignore_loglevel"
 
 # Kernel parameters applied ONLY to Normal boot mode
 # (UX settings: quiet, splash, etc. - Left empty for verbose output)


### PR DESCRIPTION
Add "net.ifnames=0" in kernel command line to assign predictable, stable network interface names for all local Ethernet, WLAN and WWAN interfaces. which is required for current automation script or configuration in axiom workflow.