### PR TITLE
chore: remove parent workspace defaults

### DIFF
--- a/.github/pkg-workflows/debian/pr-pre-post-merge.yml
+++ b/.github/pkg-workflows/debian/pr-pre-post-merge.yml
@@ -22,4 +22,4 @@ jobs:
       # PRE-MERGE: use the PR head branch (github.head_ref)
       # POST-MERGE: use the base branch name from the PR (e.g. "debian/qcom-next")
       debian-ref: ${{ (github.event.action == 'closed' && github.event.pull_request.merged) && github.event.pull_request.base.ref || github.head_ref }}
-      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}

--- a/.github/pkg-workflows/main/build-debian-package.yml
+++ b/.github/pkg-workflows/main/build-debian-package.yml
@@ -37,4 +37,4 @@ jobs:
       qcom-build-utils-ref: main
       debian-ref: ${{ inputs.debian-ref }}
       suite: ${{ inputs.suite }}
-      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}

--- a/.github/pkg-workflows/main/release.yml
+++ b/.github/pkg-workflows/main/release.yml
@@ -47,7 +47,7 @@ jobs:
       suite: ${{ github.event.inputs.suite }}
       debian-branch: ${{ github.event.inputs.debian-branch }}
       test-run: ${{ github.event.inputs.test-run == 'true' && true || false }}
-      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
     secrets:
       PAT: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
       DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -56,7 +56,6 @@ on:
       debusine-parent-workspace:
         description: Parent Debusine workspace used to create per-run child CI workspaces for Debian builds
         type: string
-        default: ci
 
     secrets:
       DEBUSINE_USER:

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -33,7 +33,6 @@ on:
       debusine-parent-workspace:
         description: Parent Debusine workspace used to create per-run child CI workspaces for Debian builds
         type: string
-        default: ci
 
     secrets:
       PAT:

--- a/.github/workflows/workflows_sync.yml
+++ b/.github/workflows/workflows_sync.yml
@@ -110,6 +110,14 @@ jobs:
             # Track if changes are needed
             isDirty=false
 
+            # Remove legacy per-repo workflows_sync workflow if present.
+            # The source of truth is qcom-build-utils/.github/workflows/workflows_sync.yml.
+            if [[ -f ".github/workflows/workflows_sync.yml" ]]; then
+              echo "    🗑️ Removing deprecated workflows_sync.yml"
+              rm ".github/workflows/workflows_sync.yml"
+              isDirty=true
+            fi
+
             # Compare and sync workflow files
             for workflow in ../qcom-build-utils/.github/pkg-workflows/main/*.yml; do
               workflow_name=$(basename "$workflow")
@@ -136,7 +144,7 @@ jobs:
               if [[ "$isDirty" == "true" ]]; then
                 echo "    📝 Creating branch and committing main branch changes"
                 git checkout -b sync/qcom-build-utils-workflows 2>&1 | sed 's/^/    /'
-                git add .github/workflows/
+                git add -A .github/workflows/
                 git commit -s -m "chore: sync workflows from qcom-build-utils" 2>&1 | sed 's/^/    /'
 
                 if [[ "$CONFIRMATION_INPUT" == "true" ]]; then

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -87,7 +87,7 @@ jobs:
       qcom-build-utils-ref: development
       debian-ref: debian/qcom-next
       suite: trixie
-      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
 ```
 
 #### Matrix-safe caller
@@ -180,7 +180,7 @@ jobs:
       suite: trixie
       debian-branch: debian/qcom-next
       test-run: false
-      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE || 'ci' }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
     secrets:
       PAT: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}
       DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}


### PR DESCRIPTION
## Summary
- remove `default: ci` from reusable workflow inputs
- pass `debusine-parent-workspace` through pkg workflow templates without hardcoded fallback
- update docs examples to match the new caller pattern

## Why
We want a single default source for parent workspace behavior in `debusine-action/lib/build` (fallback to `qli-ci`) instead of splitting defaults across caller layers.