### PR TITLE
Always use arm runner for test job

### DIFF
--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -306,7 +306,7 @@ jobs:
       workspace_url: ${{ steps.select.outputs.workspace_url }}
       srcpkg_name: ${{ steps.select.outputs.srcpkg_name }}
       srcpkg_version: ${{ steps.select.outputs.srcpkg_version }}
-    runs-on: ${{ needs.resolve.outputs.family == 'debian' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+    runs-on: ubuntu-24.04-arm
     container:
       image: ${{ needs.resolve.outputs.family == 'debian' && format('ghcr.io/qualcomm-linux/debusine-pkg-builder:{0}', needs.resolve.outputs.debian_builder_suite) || format('ghcr.io/qualcomm-linux/pkg-builder:{0}', needs.resolve.outputs.target_suite) }}
       options: --user 0:0


### PR DESCRIPTION
Always use an ARM64 runner for the package instability test