### PR TITLE
Rename ubuntu-build job ID to docker-build

### DIFF
--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -145,7 +145,7 @@ jobs:
           echo "force_docker_build=$force_docker_build" >> "$GITHUB_OUTPUT"
           echo "target_suite=$target_suite" >> "$GITHUB_OUTPUT"
 
-  ubuntu-build:
+  docker-build:
     name: Build (Docker)
     if: ${{ needs.resolve.outputs.family == 'ubuntu' || needs.resolve.outputs.force_docker_build == 'true' }}
     needs: resolve
@@ -305,11 +305,11 @@ jobs:
 
   test:
     name: Test
-    if: ${{ always() && ((needs.resolve.outputs.family == 'debian' && needs.resolve.outputs.force_docker_build != 'true' && needs.debian-build.result == 'success') || ((needs.resolve.outputs.family == 'ubuntu' || needs.resolve.outputs.force_docker_build == 'true') && needs.ubuntu-build.result == 'success')) }}
+    if: ${{ always() && ((needs.resolve.outputs.family == 'debian' && needs.resolve.outputs.force_docker_build != 'true' && needs.debian-build.result == 'success') || ((needs.resolve.outputs.family == 'ubuntu' || needs.resolve.outputs.force_docker_build == 'true') && needs.docker-build.result == 'success')) }}
     needs:
       - resolve
       - debian-build
-      - ubuntu-build
+      - docker-build
     outputs:
       workspace: ${{ steps.select.outputs.workspace }}
       workspace_url: ${{ steps.select.outputs.workspace_url }}
@@ -457,8 +457,8 @@ jobs:
           else
             echo "workspace=" >> "$GITHUB_OUTPUT"
             echo "workspace_url=" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_name=${{ needs.ubuntu-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_version=${{ needs.ubuntu-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_name=${{ needs.docker-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_version=${{ needs.docker-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
           fi
 
   finalize:


### PR DESCRIPTION
## Background

PR #151 introduced `force_docker_build` which allows Debian-family
suites to fall back to the local pkg-builder Docker container when
`DEBUSINE_TOKEN` is absent. As a result, the `ubuntu-build` job now
handles builds for both Ubuntu suites and Debian suites on the Docker
path. The job ID no longer accurately reflects its role.

## Change

Rename job ID `ubuntu-build` to `docker-build` in
`qcom-build-pkg-reusable-workflow.yml` and update all referencing
locations:

- Job-level `if:` condition
- `test` job `needs:` list
- `test` job `if:` condition
- `test` job `select` step — `srcpkg_name` output reference
- `test` job `select` step — `srcpkg_version` output reference

## Validation

Validated via `pkg-example` against `dev/workflowfixes`:

| Scenario | Expected | Result |
|---|---|---|
| PR → `qcom/debian/trixie` | Build (Debusine) runs | ✓ |
| PR → `qcom/ubuntu/resolute` | Build (Docker) runs | ✓ |
| Manual build `sid`, no force | Build (Debusine) runs | ✓ |
| Manual build `resolute` | Build (Docker) runs | ✓ |