### PR TITLE
Guard against releasing WIP changelog entries

### DIFF
--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -268,6 +268,16 @@ jobs:
           version=$(dpkg-parsechangelog --show-field Version)
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+          # Guard: refuse to release a WIP placeholder
+          if [[ "${version}" == *~ ]]; then
+            echo "Error: version '${version}' ends with '~' — update debian/changelog and remove the '~' suffix before releasing" >&2
+            exit 1
+          fi
+          if grep -q 'WIP' debian/changelog; then
+            echo "Error: debian/changelog contains 'WIP' — update changelog entry before releasing" >&2
+            exit 1
+          fi
+
           # dch expects the suite name; sid is the codename for unstable
           dch_suite="${DISTRO_CODENAME}"
           if [[ "${dch_suite}" == "sid" ]]; then
@@ -389,11 +399,11 @@ jobs:
           fi
 
           rev=$((rev + 1))
-          newversion="${upstream}-${rev}"
+          newversion="${upstream}-${rev}~"
           echo "Bumped version -> ${newversion}"
-          dch --newversion="${newversion}" --distribution=UNRELEASED --controlmaint "Initial commit"
+          dch --newversion="${newversion}" --distribution=UNRELEASED --controlmaint "WIP — update changelog before next release"
 
-          git commit -a -m "Initial commit of new version ${newversion}"
+          git commit -a -m "debian/changelog: bump to ${newversion}"
 
           git push origin "${DEBIAN_BRANCH}"
           git push origin "${DISTRO_CODENAME}/${version}"


### PR DESCRIPTION
Prevents accidentally releasing a placeholder changelog
entry without updating it first.

## Changes

**Post-release bump** (`qcom-release-reusable-workflow.yml`):
- Version bumped to `<upstream>-<rev>~` (bare tilde)
- Changelog entry text: `"WIP — update changelog before next release"`
- Commit message: `"debian/changelog: bump to <version>"`

**Guard at release time — Ubuntu path only** (`qcom-release-reusable-workflow.yml`):
- Errors out if version ends with `~`
- Errors out if `debian/changelog` contains `"WIP"`

## Why Ubuntu path only

The Debian path calls `debusine-action/lib/prepare-release` which
already handles `~` suffixes by stripping them before releasing.
The guard can be added to the Debian path later when we have
control over that script.

## Why `~`

In Debian versioning `~` sorts lower than anything, so
`1.0-2~` can never be accidentally uploaded as a valid
release version.