### PR TITLE
Map 'latest' branch suffix to sid in resolve-suite

### DIFF
--- a/.github/pkg-workflows/debian/pr-pre-post-merge.yml
+++ b/.github/pkg-workflows/debian/pr-pre-post-merge.yml
@@ -25,6 +25,10 @@ jobs:
           case "$BASE_REF" in
             qcom/ubuntu/*|qcom/debian/*)
               suite="${BASE_REF##*/}"
+              # 'latest' is not a valid suite name — map to sid
+              if [[ "$suite" == "latest" ]]; then
+                suite=sid
+              fi
               ;;
             *)
               suite=sid


### PR DESCRIPTION
## Problem

Branches named `qcom/debian/latest` use `latest` as the last
path component. The `resolve-suite` job in `pr-pre-post-merge.yml`
extracts this as the suite name, causing `pkg-builder:latest` to
be pulled instead of a valid suite image, which fails the build.

Observed in `pkg-qmi-framework` PR #20 and `pkg-gbm-msm-backend` PR #32.

## Fix

Add a check in `resolve-suite`: if the extracted suite is `latest`,
map it to `sid` (Debian unstable), which is the correct suite for
`qcom/debian/latest` branches.

## Files changed

- `.github/pkg-workflows/debian/pr-pre-post-merge.yml`