### PR TITLE
Map 'latest' suite to sid in resolve jobs

### DIFF
--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -118,6 +118,11 @@ jobs:
 
           target_suite="$SUITE_INPUT"
 
+          # 'latest' is not a valid suite name — map to sid (Debian unstable)
+          if [[ "$target_suite" == "latest" ]]; then
+            target_suite=sid
+          fi
+
           case "$target_suite" in
             trixie|sid|unstable|bookworm|forky)
               family=debian

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -88,6 +88,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          # 'latest' is not a valid suite name — map to sid (Debian unstable)
+          if [[ "$TARGET_SUITE" == "latest" ]]; then
+            TARGET_SUITE=sid
+          fi
+
           case "$TARGET_SUITE" in
             trixie|sid|unstable|bookworm|forky)
               family=debian


### PR DESCRIPTION
## Problem

Branches named `qcom/debian/latest` pass `latest` as the suite
input. `latest` is not a valid suite name — it causes
`pkg-builder:latest` to be pulled instead of a valid suite image,
failing the build at container initialization.

Observed in `pkg-qmi-framework` PR#20 and `pkg-gbm-msm-backend` PR#32.

## Fix

Map `latest` → `sid` in the `resolve` job of both reusable workflows,
before the suite classification case statement.

### `qcom-build-pkg-reusable-workflow.yml`
- Map `latest` to `sid` before classification
- Covers: `pr-pre-post-merge`, `build-debian-package`, Debian release build

### `qcom-release-reusable-workflow.yml`
- Map `latest` to `sid` before classification
- Add `target_suite` output from `resolve` job
- Replace all `inputs.suite` references in the Ubuntu release path
  with `needs.resolve.outputs.target_suite`
- Covers: Ubuntu `pkg-builder` container, changelog steps, provenance,
  build, S3 upload

## Files changed

- `.github/workflows/qcom-build-pkg-reusable-workflow.yml`
- `.github/workflows/qcom-release-reusable-workflow.yml`