### PR TITLE
fix: promote-prebuilt packages:read permission and ref to main

### DIFF
--- a/.github/pkg-workflows/main/promote-prebuilt.yml
+++ b/.github/pkg-workflows/main/promote-prebuilt.yml
@@ -37,12 +37,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: read
 
 jobs:
   promote:
-    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml@dev/pkg-bin
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml@main
     with:
-      qcom-build-utils-ref: dev/pkg-bin
+      qcom-build-utils-ref: main
       debian-branch: ${{inputs.debian-branch}}
       new-tag: ${{inputs.new-tag}}
       new-package-name: ${{inputs.new-package-name}}

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -436,6 +436,34 @@ jobs:
         run: |
           set -euxo pipefail
 
+          # Add qsc-deb-releases so Qualcomm package dependencies are resolvable
+          suite="${{ needs.resolve.outputs.target_suite }}"
+          install -d /etc/apt/keyrings /etc/apt/sources.list.d
+          cat > /etc/apt/keyrings/qsc-deb-releases.asc <<'KEYEOF'
+          -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+          mDMEaGwEMxYJKwYBBAHaRw8BAQdAg8Nfdby/c9Y6bctGLnGJrhMhedCGfYzrp9Sa
+          RWtQgDe0NXFzY19hcHRfcmVwby0wNzA3MjAyNSA8YXJ0aWZhY3RvcnkuY29yZUBx
+          dWFsY29tbS5jb20+iJkEExYKAEEWIQRyQhNJGZOZvf1sqY3IwASzX5SqWwUCaGwE
+          MwIbAwUJBaOagAULCQgHAgIiAgYVCgkICwIEFgIDAQIeBwIXgAAKCRDIwASzX5Sq
+          W0k4AQCzVUgf+ydkoHdxKiHzwZjDowL38lAp92zlvQqK2r+9kQEAxZYBhPQ4ZVo9
+          RL2bOrJexNAJyYqRamtrU+jkBn1wjQq4OARobAQzEgorBgEEAZdVAQUBAQdASOGZ
+          gHVoc7BboK7yCC3bSib9NLBlrsA47RRvT7fPHhoDAQgHiH4EGBYKACYWIQRyQhNJ
+          GZOZvf1sqY3IwASzX5SqWwUCaGwEMwIbDAUJBaOagAAKCRDIwASzX5SqWzH3AP94
+          HDue14QrgcEsyXCElAAZxYqiDMFu663G3ki0lGB1vAEAz0tqLiapgthdSt/c/2YQ
+          tej7g/77RkEpjjhnWiLMiAM=
+          =7H+M
+          -----END PGP PUBLIC KEY BLOCK-----
+          KEYEOF
+          cat > /etc/apt/sources.list.d/qsc-deb-releases.sources <<EOF
+          Types: deb
+          URIs: https://qartifactory-edge.qualcomm.com/artifactory/qsc-deb-releases
+          Suites: $suite
+          Components: main
+          Signed-By: /etc/apt/keyrings/qsc-deb-releases.asc
+          Enabled: yes
+          EOF
+
           apt-get update
 
           debs=$(find "$PWD/build-area" -type f -name '*.deb' | sort)
@@ -484,4 +512,3 @@ jobs:
           echo "workspace_url=${{ needs.test.outputs.workspace_url }}" >> "$GITHUB_OUTPUT"
           echo "srcpkg_name=${{ needs.test.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
           echo "srcpkg_version=${{ needs.test.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
-

--- a/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml
+++ b/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml
@@ -231,7 +231,7 @@ jobs:
         run: |
           cd ./package-repo
 
-          gh auth login --with-token <<< "${{secrets.GITHUB_TOKEN}}"
+          gh auth login --with-token <<< "${{secrets.DEB_PKG_BOT_CI_TOKEN}}"
 
           PR_TITLE="Promotion to ${{env.NEW_DEBIAN_VERSION}} (Artifactory tag: ${{inputs.new-tag}})"
 


### PR DESCRIPTION
## Problem

Three separate failures fixed in this PR:

### 1. `startup_failure` — container image could not be pulled
`ghcr.io/qualcomm-linux/pkg-builder:noble` is a private GHCR image. `GITHUB_TOKEN` can only pull it if the caller declares `packages: read`. The template was missing this, so the job failed before any step ran.

### 2. `createPullRequest` — GitHub Actions not permitted to create PRs
After fixing the container pull, the "Open Promotion PR" step failed with:
```
GitHub Actions is not permitted to create or approve pull requests
```
`GITHUB_TOKEN` cannot create PRs when `default_workflow_permissions: read` is set on the repo. Restored `DEB_PKG_BOT_CI_TOKEN` for the `gh pr create` step — it is already available via `secrets: inherit`.

### 3. Docker installability test — unmet dependencies
The Docker installability test was running `apt-get install` against only the base Ubuntu suite. Dependencies live in `qsc-deb-releases` and were not resolvable, causing the test to fail even when the package built correctly.

Added the `qsc-deb-releases` keyring and apt source before `apt-get update` in the Docker test step — matching what the Debusine installability path already does.
