### PR TITLE
refactor: extract push-provenance to a script

### DIFF
--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -422,41 +422,7 @@ jobs:
           SUITE: ${{ inputs.suite }}
           BOT_NAME: ${{ vars.DEB_PKG_BOT_CI_NAME }}
           BOT_EMAIL: ${{ vars.DEB_PKG_BOT_CI_EMAIL }}
-        run: |
-          git clone "https://x-access-token:${GH_PAT}@github.com/qualcomm-linux/qcom-distro-artifacts.git" ./qcom-distro-artifacts
-
-          cd qcom-distro-artifacts
-
-          git config user.name "${BOT_NAME}"
-          git config user.email "${BOT_EMAIL}"
-
-          mkdir -p "${SUITE}"
-
-          SUITE_PROVENANCE="${SUITE}/provenance.json"
-          NEW_PROVENANCE="../build/provenance.json"
-
-          if [[ -f "${SUITE_PROVENANCE}" ]]; then
-            jq -s --indent 2 '.[0] * .[1]' "${SUITE_PROVENANCE}" "${NEW_PROVENANCE}" > /tmp/merged_provenance.json
-            mv /tmp/merged_provenance.json "${SUITE_PROVENANCE}"
-          else
-            cp "${NEW_PROVENANCE}" "${SUITE_PROVENANCE}"
-          fi
-
-          git add "${SUITE_PROVENANCE}"
-
-          if git diff --cached --quiet; then
-            echo "Provenance unchanged, nothing to commit"
-          else
-            SOURCE_PKG=$(jq -r 'keys[0]' "${NEW_PROVENANCE}")
-            VERSION=$(jq -r '.[keys[0]].source_pkg_version' "${NEW_PROVENANCE}")
-            git commit -m "provenance: update ${SOURCE_PKG} ${VERSION} for ${SUITE}"
-
-            for attempt in 1 2 3; do
-              git push origin main && break
-              echo "Push attempt ${attempt} failed, rebasing and retrying..."
-              git pull --rebase origin main
-            done
-          fi
+        run: ./qcom-build-utils/scripts/push-provenance.sh
 
       - name: Prepare build logs for upload
         working-directory: ./build/

--- a/scripts/push-provenance.sh
+++ b/scripts/push-provenance.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# push-provenance.sh — Push provenance.json to qcom-distro-artifacts.
+#
+# Clones qcom-distro-artifacts, merges the new provenance entry into the
+# suite-level provenance.json, and pushes with up to 3 rebase retries.
+#
+# Required environment variables:
+#   GH_PAT     — GitHub PAT with write access to qcom-distro-artifacts
+#   SUITE      — suite name, e.g. resolute, noble
+#   BOT_NAME   — git commit author name
+#   BOT_EMAIL  — git commit author email
+#
+# Expected input file:
+#   build/provenance.json  — written by create-provenance.sh
+
+set -euo pipefail
+
+: "${GH_PAT:?GH_PAT is required}"
+: "${SUITE:?SUITE is required}"
+: "${BOT_NAME:?BOT_NAME is required}"
+: "${BOT_EMAIL:?BOT_EMAIL is required}"
+
+git clone "https://x-access-token:${GH_PAT}@github.com/qualcomm-linux/qcom-distro-artifacts.git" ./qcom-distro-artifacts
+
+cd qcom-distro-artifacts
+
+git config user.name "${BOT_NAME}"
+git config user.email "${BOT_EMAIL}"
+
+mkdir -p "${SUITE}"
+
+SUITE_PROVENANCE="${SUITE}/provenance.json"
+NEW_PROVENANCE="../build/provenance.json"
+
+if [[ -f "${SUITE_PROVENANCE}" ]]; then
+  jq -s --indent 2 '.[0] * .[1]' "${SUITE_PROVENANCE}" "${NEW_PROVENANCE}" > /tmp/merged_provenance.json
+  mv /tmp/merged_provenance.json "${SUITE_PROVENANCE}"
+else
+  cp "${NEW_PROVENANCE}" "${SUITE_PROVENANCE}"
+fi
+
+git add "${SUITE_PROVENANCE}"
+
+if git diff --cached --quiet; then
+  echo "Provenance unchanged, nothing to commit"
+else
+  SOURCE_PKG=$(jq -r 'keys[0]' "${NEW_PROVENANCE}")
+  VERSION=$(jq -r '.[keys[0]].source_pkg_version' "${NEW_PROVENANCE}")
+  git commit -m "provenance: update ${SOURCE_PKG} ${VERSION} for ${SUITE}"
+
+  for attempt in 1 2 3; do
+    git push origin main && break
+    echo "Push attempt ${attempt} failed, rebasing and retrying..."
+    git pull --rebase origin main
+  done
+fi


### PR DESCRIPTION
## Summary

Moves the 43-line `Push provenance to qcom-distro-artifacts` inline shell block out of `qcom-release-reusable-workflow.yml` into `scripts/push-provenance.sh`.

The workflow step becomes a single line:
```yaml
- name: Push provenance to qcom-distro-artifacts
  if: ${{ !inputs.test-run }}
  env:
    GH_PAT: ${{ secrets.PAT }}
    SUITE: ${{ inputs.suite }}
    BOT_NAME: ${{ vars.DEB_PKG_BOT_CI_NAME }}
    BOT_EMAIL: ${{ vars.DEB_PKG_BOT_CI_EMAIL }}
  run: ./qcom-build-utils/scripts/push-provenance.sh
```

## No behaviour change
All logic is identical — clones qcom-distro-artifacts, merges provenance JSON, pushes with 3-attempt rebase retry. All env vars unchanged. Script validates required vars at startup.