### PR TITLE
Support Debusine builds from externally-prepared source trees: srcpkg-artifact delivery and assemble-orig flag

### DIFF
--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -73,6 +73,15 @@ on:
         type: string
         default: ""
 
+      assemble-orig:
+        description: |
+          When true, generate-source-package creates the .orig.tar.gz directly
+          from the source tree and invokes dpkg-buildpackage -S, bypassing gbp.
+          Use for packages whose source tree is assembled at CI time with no
+          upstream tarball available via gbp or pristine-tar.
+        type: boolean
+        default: false
+
     secrets:
       DEBUSINE_USER:
         required: false
@@ -303,6 +312,7 @@ jobs:
         id: generate-source-package
         env:
           SUITE_INPUT: ${{ needs.resolve.outputs.target_suite }}
+          DEBUSINE_ASSEMBLE_ORIG: ${{ inputs.assemble-orig }}
         run: |
           set -ex
           SUITE="$SUITE_INPUT" debusine-action/lib/generate-source-package

--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -63,6 +63,16 @@ on:
         type: boolean
         default: false
 
+      srcpkg-artifact:
+        description: |
+          Name of a GitHub Actions artifact containing a pre-prepared source tree
+          to use as srcpkg/. When set, the debian-ref checkout is skipped and the
+          artifact is downloaded instead. Used for packages like pkg-linux-qcom
+          where the source tree is assembled at CI time rather than managed in a
+          single git repository.
+        type: string
+        default: ""
+
     secrets:
       DEBUSINE_USER:
         required: false
@@ -94,7 +104,8 @@ permissions:
   packages: read
 
 env:
-  DEBUSINE_ACTION_REF: main
+  # TODO: update to main once feat/generate-source-package-non-gbp-quilt is merged.
+  DEBUSINE_ACTION_REF: feat/generate-source-package-non-gbp-quilt
 
 jobs:
   resolve:
@@ -251,12 +262,20 @@ jobs:
             lib
 
       - name: Checkout Repository
+        if: ${{ inputs.srcpkg-artifact == '' }}
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.debian-ref }}
           path: srcpkg
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Download pre-prepared source tree
+        if: ${{ inputs.srcpkg-artifact != '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.srcpkg-artifact }}
+          path: srcpkg
 
       - name: Prepare release
         if: ${{ inputs.release }}
@@ -353,12 +372,19 @@ jobs:
             lib
 
       - name: Checkout Repository
-        if: ${{ needs.resolve.outputs.family == 'debian' && needs.resolve.outputs.force_docker_build != 'true' }}
+        if: ${{ needs.resolve.outputs.family == 'debian' && needs.resolve.outputs.force_docker_build != 'true' && inputs.srcpkg-artifact == '' }}
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.debian-ref }}
           path: srcpkg
           fetch-depth: 1
+
+      - name: Download pre-prepared source tree
+        if: ${{ needs.resolve.outputs.family == 'debian' && inputs.srcpkg-artifact != '' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.srcpkg-artifact }}
+          path: srcpkg
 
       - name: Validate installability from Debusine CI workspace
         # Temporarily disabled while dependency repository injection is unresolved.

--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -275,7 +275,19 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.srcpkg-artifact }}
-          path: srcpkg
+          path: /tmp/srcpkg-artifact
+
+      - name: Extract pre-prepared source tree
+        if: ${{ inputs.srcpkg-artifact != '' }}
+        run: |
+          # The artifact is a tar.gz archive created by the caller to preserve
+          # Unix execute permissions on kernel build scripts. zip format (used
+          # by actions/upload-artifact) strips execute bits; tar does not.
+          # --strip-components=1 extracts the top-level directory directly into
+          # srcpkg/ without depending on its name inside the archive.
+          mkdir srcpkg
+          tar xzf /tmp/srcpkg-artifact/kernel-srcpkg.tar.gz \
+            -C srcpkg --strip-components=1
 
       - name: Prepare release
         if: ${{ inputs.release }}
@@ -384,7 +396,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.srcpkg-artifact }}
-          path: srcpkg
+          path: /tmp/srcpkg-artifact
+
+      - name: Extract pre-prepared source tree
+        if: ${{ needs.resolve.outputs.family == 'debian' && inputs.srcpkg-artifact != '' }}
+        run: |
+          mkdir srcpkg
+          tar xzf /tmp/srcpkg-artifact/kernel-srcpkg.tar.gz \
+            -C srcpkg --strip-components=1
 
       - name: Validate installability from Debusine CI workspace
         # Temporarily disabled while dependency repository injection is unresolved.

--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -113,8 +113,7 @@ permissions:
   packages: read
 
 env:
-  # TODO: update to main once feat/generate-source-package-non-gbp-quilt is merged.
-  DEBUSINE_ACTION_REF: feat/generate-source-package-non-gbp-quilt
+  DEBUSINE_ACTION_REF: main
 
 jobs:
   resolve:

--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -294,8 +294,10 @@ jobs:
           # by actions/upload-artifact) strips execute bits; tar does not.
           # --strip-components=1 extracts the top-level directory directly into
           # srcpkg/ without depending on its name inside the archive.
+          # The artifact contains exactly one *.tar.gz, so the glob below stays
+          # unambiguous while decoupling this step from the producer's filename.
           mkdir srcpkg
-          tar xzf /tmp/srcpkg-artifact/kernel-srcpkg.tar.gz \
+          tar xzf /tmp/srcpkg-artifact/*.tar.gz \
             -C srcpkg --strip-components=1
 
       - name: Prepare release
@@ -411,8 +413,10 @@ jobs:
       - name: Extract pre-prepared source tree
         if: ${{ needs.resolve.outputs.family == 'debian' && inputs.srcpkg-artifact != '' }}
         run: |
+          # Single *.tar.gz in the artifact; glob decouples from the
+          # producer's filename (see build-job extract step for rationale).
           mkdir srcpkg
-          tar xzf /tmp/srcpkg-artifact/kernel-srcpkg.tar.gz \
+          tar xzf /tmp/srcpkg-artifact/*.tar.gz \
             -C srcpkg --strip-components=1
 
       - name: Validate installability from Debusine CI workspace


### PR DESCRIPTION
## Summary

Extend the reusable workflow to support packages that do not follow the
single-repository packaging model. Two new inputs — `srcpkg-artifact`
and `assemble-orig` — unlock Debusine builds for packages like
`pkg-linux-qcom` where the kernel source (`qualcomm-linux/kernel`) and
the packaging metadata (`debian/`) live in separate repositories and are
injected into a single source tree at build time by `prepare-source.sh`.
The resulting tree has no upstream tag, no `pristine-tar` branch, and no
`debian/gbp.conf` — making the existing git-checkout and gbp-based paths
structurally inapplicable.

---

## Motivation

The existing workflow has a single model for source tree delivery: check
out the packaging repository at `debian-ref` into `srcpkg/`. This works
for repositories where the upstream source and `debian/` metadata are
co-located or linked via gbp conventions.

`pkg-linux-qcom` does not fit this model:

- The kernel source is a shallow clone of `qualcomm-linux/kernel` at a
  `qcom-next-*` tag, optionally patched with qcom-next and kernel-topics
  PRs.
- The `debian/` metadata is injected by `prepare-source.sh` from the
  `pkg-linux-qcom` packaging repository into the kernel source tree.
- The assembled tree is ephemeral — it exists only in the build workspace
  and has no corresponding git ref, no upstream tag, no `pristine-tar`
  branch, and no `debian/gbp.conf`.

Consequently:
- There is no `debian-ref` that can be checked out to produce a buildable
  `srcpkg/`.
- `gbp buildpackage` cannot reconstruct the `.orig.tar.gz` because there
  is no pristine-tar data and no upstream tag to fetch from.

Both failure modes are structural, not configuration errors. They require
new delivery and source-package-generation paths, not workarounds.

---

## New inputs

### `srcpkg-artifact` — controls source tree delivery

When empty (the default), the existing behaviour is preserved: the
packaging repository is checked out at `debian-ref` in both the
`debian-build` and `test` jobs. No existing callers are affected.

When set, the named artifact is expected to be a `tar.gz` archive of the
prepared source tree. The archive is downloaded to a staging directory
and extracted with `--strip-components=1` directly into `srcpkg/`.

**Why `tar.gz` and not a direct directory upload?**
`actions/upload-artifact` uses zip format internally, which strips Unix
execute permissions. Kernel build scripts (e.g. `scripts/cc-version.sh`)
require execute permission; without it, `make defconfig` fails with
`Permission denied` inside the Debusine build environment. `tar`
preserves permissions end-to-end; the zip layer wraps a single opaque
file and permissions are restored on extraction.

The `debian-ref` input remains required by the workflow schema but is not
consumed for checkout when `srcpkg-artifact` is set.

### `assemble-orig` — controls source package generation strategy

When false (the default), `generate-source-package` uses `gbp buildpackage`
to reconstruct the orig tarball from pristine-tar or an upstream tag.

When true, passes `DEBUSINE_ASSEMBLE_ORIG=true` to `generate-source-package`
(added in **qualcomm-linux/debusine-action**
`feat/generate-source-package-non-gbp-quilt`), which:

1. Creates `../<pkg>_<upstream_ver>.orig.tar.gz` directly from the source
   tree, excluding `./debian` and `./.git`
2. Invokes `dpkg-buildpackage -S -sa -d -nc -us -uc` to produce the
   `.dsc`, `.debian.tar.xz`, and `.changes` files

This is required for source trees that have no upstream tarball available
via gbp or pristine-tar — specifically, shallow kernel clones assembled
at build time with no version-control history that gbp can interrogate.

---

## Design

The two inputs are orthogonal:
- `srcpkg-artifact` determines **where** the source tree comes from
- `assemble-orig` determines **how** the source package is generated from it

A caller can use either independently, though for `pkg-linux-qcom` both
are required together.

---

## Dependency

This PR depends on:
- https://github.com/qualcomm-linux/debusine-action/pull/27:
  adds `DEBUSINE_ASSEMBLE_ORIG` support to `generate-source-package`.

`DEBUSINE_ACTION_REF` is now pinned to `main` — https://github.com/qualcomm-linux/debusine-action/pull/27 merged.

