### PR TITLE
build: default debian-ref to qcom/debian/latest

### DIFF
--- a/.github/pkg-workflows/main/build-debian-package.yml
+++ b/.github/pkg-workflows/main/build-debian-package.yml
@@ -7,10 +7,10 @@ on:
     inputs:
 
       debian-ref:
-        description: The debian ref to build. For example branch "debian/qcom-next" or tag "debian/1.0.0-1"
+        description: The debian ref to build. For example branch "qcom/debian/latest" or tag "debian/1.0.0-1"
         type: string
         required: true
-        default: debian/qcom-next
+        default: qcom/debian/latest
 
       suite:
         description: The distribution codename or Debian suite to build for. Ex noble, questing, resolute, trixie, sid, unstable

--- a/.github/pkg-workflows/main/promote-prebuilt.yml
+++ b/.github/pkg-workflows/main/promote-prebuilt.yml
@@ -5,10 +5,10 @@ on:
     inputs:
 
       debian-branch:
-        description: The debian branch to apply the promotion to. For example "debian/qcom-next"
+        description: The debian branch to apply the promotion to. For example "qcom/debian/latest"
         type: string
         required: false
-        default: debian/qcom-next
+        default: qcom/debian/latest
 
       new-tag:
         description: |

--- a/.github/pkg-workflows/main/promote-upstream.yml
+++ b/.github/pkg-workflows/main/promote-upstream.yml
@@ -5,10 +5,10 @@ on:
     inputs:
 
       debian-branch:
-        description: The debian branch to apply the promotion to. For example branch "debian/qcom-next"
+        description: The debian branch to apply the promotion to. For example branch "qcom/debian/latest"
         type: string
         required: false
-        default: debian/qcom-next
+        default: qcom/debian/latest
 
       upstream-tag:
         description: The upstream tag to promote this package repo to. Eg, v1.1.0 or 1.2.0, depending on the versioning style

--- a/.github/pkg-workflows/main/release.yml
+++ b/.github/pkg-workflows/main/release.yml
@@ -22,10 +22,10 @@ on:
           - sid
 
       debian-branch:
-        description: The debian branch to use to execute the release from. For example branch "debian/qcom-next"
+        description: The debian branch to use to execute the release from. For example branch "qcom/debian/latest"
         type: string
         required: false
-        default: debian/qcom-next
+        default: qcom/debian/latest
 
       test-run:
         description: |

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -17,7 +17,6 @@ on:
         description: The debian ref to build. For example branch "qcom/debian/latest" or tag "debian/1.0.0-1"
         type: string
         required: true
-        default: qcom/debian/latest
 
       suite:
         description: The distribution codename or Debian suite to build for. Ex noble, questing, resolute, trixie, sid, unstable

--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -14,10 +14,10 @@ on:
         required: true
 
       debian-ref:
-        description: The debian ref to build. For example branch "debian/qcom-next" or tag "debian/1.0.0-1"
+        description: The debian ref to build. For example branch "qcom/debian/latest" or tag "debian/1.0.0-1"
         type: string
         required: true
-        default: debian/qcom-next
+        default: qcom/debian/latest
 
       suite:
         description: The distribution codename or Debian suite to build for. Ex noble, questing, resolute, trixie, sid, unstable

--- a/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml
+++ b/.github/workflows/qcom-promote-prebuilt-reusable-workflow.yml
@@ -19,10 +19,9 @@ on:
         required: true
 
       debian-branch:
-        description: The debian branch to apply the promotion to. For example "debian/qcom-next"
+        description: The debian branch to apply the promotion to. For example "qcom/debian/latest"
         type: string
         required: false
-        default: debian/qcom-next
 
       new-tag:
         description: |

--- a/.github/workflows/qcom-promote-upstream-reusable-workflow.yml
+++ b/.github/workflows/qcom-promote-upstream-reusable-workflow.yml
@@ -16,10 +16,9 @@ on:
         required: true
 
       debian-branch:
-        description: The debian branch to apply the promotion to. For example branch "debian/qcom-next"
+        description: The debian branch to apply the promotion to. For example branch "qcom/debian/latest"
         type: string
         required: false
-        default: debian/qcom-next
 
       upstream-tag:
         description: The tag in the upstream repo to promote to.

--- a/.github/workflows/qcom-release-reusable-workflow.yml
+++ b/.github/workflows/qcom-release-reusable-workflow.yml
@@ -13,10 +13,9 @@ on:
         required: true
 
       debian-branch:
-        description: The debian branch to use to execute the release from. For example branch "debian/qcom-next"
+        description: The debian branch to use to execute the release from. For example branch "qcom/debian/latest"
         type: string
         required: false
-        default: debian/qcom-next
 
       suite:
         description: The distribution codename or Debian suite to build and release for. Ex noble, questing, resolute, trixie, sid


### PR DESCRIPTION
## Summary
- change the build caller template default `debian-ref` to `qcom/debian/latest`
- change the reusable build workflow default `debian-ref` to `qcom/debian/latest`
- update the example text in both files to match

## Why
The branch naming model is moving away from `debian/qcom-next` toward suite and latest branches under `qcom/*`.

## Validation
- local diff review only (YAML input defaults/descriptions update)
