### PR TITLE
build: temporarily disable installability Test steps

### DIFF
--- a/.github/workflows/qcom-build-pkg-reusable-workflow.yml
+++ b/.github/workflows/qcom-build-pkg-reusable-workflow.yml
@@ -362,7 +362,8 @@ jobs:
           fetch-depth: 1
 
       - name: Validate installability from Debusine CI workspace
-        if: ${{ needs.resolve.outputs.family == 'debian' && needs.resolve.outputs.force_docker_build != 'true' }}
+        # Temporarily disabled while dependency repository injection is unresolved.
+        if: ${{ false }}
         env:
           DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
           DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
@@ -437,7 +438,8 @@ jobs:
           tar -C build-area -xzf docker-build-area.tgz
 
       - name: Validate installability from Docker build artifacts
-        if: ${{ needs.resolve.outputs.family == 'ubuntu' || needs.resolve.outputs.force_docker_build == 'true' }}
+        # Temporarily disabled while dependency repository injection is unresolved.
+        if: ${{ false }}
         run: |
           set -euxo pipefail
 
@@ -517,3 +519,14 @@ jobs:
           echo "workspace_url=${{ needs.test.outputs.workspace_url }}" >> "$GITHUB_OUTPUT"
           echo "srcpkg_name=${{ needs.test.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
           echo "srcpkg_version=${{ needs.test.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Note temporary installability policy
+        run: |
+          {
+            echo "## Temporary Test Policy"
+            echo
+            echo ":warning: Installability validation is temporarily disabled."
+            echo
+            echo "- Skipped: Validate installability from Debusine CI workspace"
+            echo "- Skipped: Validate installability from Docker build artifacts"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- temporarily disable installability validation in the reusable build workflow `Test` job
- skip both paths:
  - `Validate installability from Debusine CI workspace`
  - `Validate installability from Docker build artifacts`
- add an explicit warning step so the temporary state is visible in run logs

## Why
Today the installability checks are unstable when package dependencies require
additional apt repositories that the workflow cannot currently inject.

This change keeps `Test` green while preserving build outputs and workflow
output selection.

## Scope
- changes only `.github/workflows/qcom-build-pkg-reusable-workflow.yml`
- temporary behavior until dependency repository injection is implemented

## Validation
- workflow YAML diff reviewed locally
