### PR TITLE
ci: support suite-aware extra repos

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -162,17 +162,14 @@ runs:
 
         # Optional repo-local extension point for additional build-dependency apt repos.
         # Each non-empty, non-comment line in debian/extra-repositories.txt is passed
-        # through to sbuild as --extra-repository "<line>".
+        # to sbuild as --extra-repository "<line>".
         #
         # Supported entry formats:
-        #   deb [arch=arm64 ...] https://example.org/repo {suite} main
+        #   deb [arch=arm64 ...] https://example.org/repo noble main
         #     -> applies to all suites
         #
         #   [noble,questing] deb [arch=arm64 ...] https://ppa.launchpadcontent.net/org/ppa/ubuntu noble main
         #     -> applies only when target suite is listed
-        #
-        # Placeholders replaced with the runtime suite:
-        #   {suite}, {SUITE}, ${suite}, ${SUITE}, @suite@, @SUITE@
         EXTRA_REPOSITORIES_FILE="./debian/extra-repositories.txt"
         target_suite="${{inputs.suite}}"
         if [[ "$target_suite" == "unstable" ]]; then
@@ -192,33 +189,35 @@ runs:
 
             repo_entry="$line"
 
-            if [[ "$line" =~ ^\[([^][]+)\][[:space:]]+(.+)$ ]]; then
-              suites_csv="${BASH_REMATCH[1]}"
-              repo_entry="${BASH_REMATCH[2]}"
-              include_entry=false
+            if [[ "$line" == \[* ]]; then
+              if [[ "$line" =~ ^\[([^][]+)\][[:space:]]+(.+)$ ]]; then
+                suites_csv="${BASH_REMATCH[1]}"
+                repo_entry="${BASH_REMATCH[2]}"
+                include_entry=false
 
-              IFS=',' read -ra suite_filters <<< "$suites_csv"
-              for suite_filter in "${suite_filters[@]}"; do
-                suite_filter="$(printf '%s' "$suite_filter" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
-                [[ -n "$suite_filter" ]] || continue
-                if [[ "$suite_filter" == "$target_suite" || "$suite_filter" == "all" || "$suite_filter" == "*" ]]; then
-                  include_entry=true
-                  break
+                IFS=',' read -ra suite_filters <<< "$suites_csv"
+                for suite_filter in "${suite_filters[@]}"; do
+                  suite_filter="$(printf '%s' "$suite_filter" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+                  [[ -n "$suite_filter" ]] || continue
+                  if [[ "$suite_filter" == "unstable" ]]; then
+                    suite_filter="sid"
+                  fi
+                  if [[ "$suite_filter" == "$target_suite" ]]; then
+                    include_entry=true
+                    break
+                  fi
+                done
+
+                if [[ "$include_entry" != true ]]; then
+                  echo "ℹ️ Skipping entry with suite filter [${suites_csv}] for target suite ${target_suite}"
+                  continue
                 fi
-              done
-
-              if [[ "$include_entry" != true ]]; then
-                echo "ℹ️ Skipping entry with suite filter [${suites_csv}] for target suite ${target_suite}"
-                continue
+              else
+                echo "::error::Invalid ${EXTRA_REPOSITORIES_FILE} entry '${line}'. Expected '[suite1,suite2] deb ...' or a plain 'deb ...' line."
+                exit 1
               fi
             fi
 
-            repo_entry="${repo_entry//\$\{suite\}/$target_suite}"
-            repo_entry="${repo_entry//\$\{SUITE\}/$target_suite}"
-            repo_entry="${repo_entry//\{suite\}/$target_suite}"
-            repo_entry="${repo_entry//\{SUITE\}/$target_suite}"
-            repo_entry="${repo_entry//@suite@/$target_suite}"
-            repo_entry="${repo_entry//@SUITE@/$target_suite}"
             repo_entry="$(printf '%s' "$repo_entry" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
             [[ -n "$repo_entry" ]] || continue
 

--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -160,6 +160,87 @@ runs:
         # subsequent cd operations might change the working directory.
         BUILD_DIR_ABS=$(realpath "../${{inputs.build-dir}}")
 
+        # Optional repo-local extension point for additional build-dependency apt repos.
+        # Each non-empty, non-comment line in debian/extra-repositories.txt is passed
+        # through to sbuild as --extra-repository "<line>".
+        #
+        # Supported entry formats:
+        #   deb [arch=arm64 ...] https://example.org/repo {suite} main
+        #     -> applies to all suites
+        #
+        #   [noble,questing] deb [arch=arm64 ...] https://ppa.launchpadcontent.net/org/ppa/ubuntu noble main
+        #     -> applies only when target suite is listed
+        #
+        # Placeholders replaced with the runtime suite:
+        #   {suite}, {SUITE}, ${suite}, ${SUITE}, @suite@, @SUITE@
+        EXTRA_REPOSITORIES_FILE="./debian/extra-repositories.txt"
+        target_suite="${{inputs.suite}}"
+        if [[ "$target_suite" == "unstable" ]]; then
+          target_suite="sid"
+        fi
+        extra_repository_values=()
+        extra_repository_args=()
+        declare -A extra_repository_seen=()
+
+        if [[ -f "$EXTRA_REPOSITORIES_FILE" ]]; then
+          echo "ℹ️ Found ${EXTRA_REPOSITORIES_FILE}; loading extra sbuild repositories"
+
+          while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
+            line="$(printf '%s' "$raw_line" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+            [[ -n "$line" ]] || continue
+            [[ "$line" =~ ^# ]] && continue
+
+            repo_entry="$line"
+
+            if [[ "$line" =~ ^\[([^][]+)\][[:space:]]+(.+)$ ]]; then
+              suites_csv="${BASH_REMATCH[1]}"
+              repo_entry="${BASH_REMATCH[2]}"
+              include_entry=false
+
+              IFS=',' read -ra suite_filters <<< "$suites_csv"
+              for suite_filter in "${suite_filters[@]}"; do
+                suite_filter="$(printf '%s' "$suite_filter" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+                [[ -n "$suite_filter" ]] || continue
+                if [[ "$suite_filter" == "$target_suite" || "$suite_filter" == "all" || "$suite_filter" == "*" ]]; then
+                  include_entry=true
+                  break
+                fi
+              done
+
+              if [[ "$include_entry" != true ]]; then
+                echo "ℹ️ Skipping entry with suite filter [${suites_csv}] for target suite ${target_suite}"
+                continue
+              fi
+            fi
+
+            repo_entry="${repo_entry//\$\{suite\}/$target_suite}"
+            repo_entry="${repo_entry//\$\{SUITE\}/$target_suite}"
+            repo_entry="${repo_entry//\{suite\}/$target_suite}"
+            repo_entry="${repo_entry//\{SUITE\}/$target_suite}"
+            repo_entry="${repo_entry//@suite@/$target_suite}"
+            repo_entry="${repo_entry//@SUITE@/$target_suite}"
+            repo_entry="$(printf '%s' "$repo_entry" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+            [[ -n "$repo_entry" ]] || continue
+
+            if [[ -n "${extra_repository_seen[$repo_entry]+x}" ]]; then
+              continue
+            fi
+            extra_repository_seen["$repo_entry"]=1
+
+            extra_repository_values+=("$repo_entry")
+            extra_repository_args+=(--extra-repository "$repo_entry")
+          done < "$EXTRA_REPOSITORIES_FILE"
+
+          if (( ${#extra_repository_values[@]} > 0 )); then
+            echo "ℹ️ Loaded ${#extra_repository_values[@]} extra repository entries:"
+            printf '  - %s\n' "${extra_repository_values[@]}"
+          else
+            echo "ℹ️ ${EXTRA_REPOSITORIES_FILE} has no active entries (only blank/comment lines)"
+          fi
+        else
+          echo "ℹ️ No ${EXTRA_REPOSITORIES_FILE} found; using default repositories only"
+        fi
+
         set +e
 
         if [[ "$PREBUILT_MODE" == "true" ]]; then
@@ -201,6 +282,7 @@ runs:
                    $lintian_flag \
                    --build-dir "$BUILD_DIR_ABS" \
                    --build-dep-resolver=apt \
+                   "${extra_repository_args[@]}" \
                    "$DSC_FILE"
           else
             # ℹ️ Prebuilt mode + native source format: invoke sbuild directly —
@@ -212,7 +294,8 @@ runs:
                    --dist=${{inputs.suite}} \
                    $lintian_flag \
                    --build-dir "$BUILD_DIR_ABS" \
-                   --build-dep-resolver=apt
+                   --build-dep-resolver=apt \
+                   "${extra_repository_args[@]}"
           fi
 
         else
@@ -220,17 +303,26 @@ runs:
           # --git-ignore-branch is necessary because the debian branch actually checked out can be any (ex, debian/1.0.0) because we can build any previous tag
           # ℹ️ chroot mode unshare is important to bypass privilege issues with the mounting
           # Host Architecture: The architecture for which the binaries are being built (invariably arm64).
+          sbuild_builder_cmd=(
+            sbuild
+            --no-clean-source
+            --dpkg-source-opt=--extend-diff-ignore=^\\.github
+            --host=arm64
+            --build=${{env.BUILD_ARCH}}
+            --dist=${{inputs.suite}}
+            "$lintian_flag"
+            --build-dir
+            "$BUILD_DIR_ABS"
+            --build-dep-resolver=apt
+            "${extra_repository_args[@]}"
+          )
+          printf -v sbuild_builder_escaped '%q ' "${sbuild_builder_cmd[@]}"
+          sbuild_builder_escaped="${sbuild_builder_escaped% }"
+
           gbp buildpackage \
             --git-no-pristine-tar \
             --git-ignore-branch \
-            --git-builder="sbuild --no-clean-source \
-                                  --dpkg-source-opt="--extend-diff-ignore=^\\.github" \
-                                   --host=arm64 \
-                                   --build=${{env.BUILD_ARCH}} \
-                                   --dist=${{inputs.suite}} \
-                                   $lintian_flag \
-                                   --build-dir $BUILD_DIR_ABS \
-                                   --build-dep-resolver=apt"
+            --git-builder="$sbuild_builder_escaped"
         fi
 
         RET=$?

--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -96,7 +96,7 @@ permissions:
   packages: read
 
 env:
-  DEBUSINE_ACTION_REF: main
+  DEBUSINE_ACTION_REF: dev/sbeaudoi-extra-repositories
 
 jobs:
   resolve:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,8 @@ orchestration around build, test, promotion, and release flows.
 - Supported entry styles:
   - global entries (apply to all suites)
   - suite-filtered entries (for example `[noble,questing] deb ...`)
-  - wildcards (`[all]` or `[*]`)
-- Suite placeholders are expanded at runtime:
-  - `{suite}`, `{SUITE}`, `${suite}`, `${SUITE}`, `@suite@`, `@SUITE@`
+- Suite filters are exact matches against the build suite.
+- `unstable` and `sid` are treated as equivalent for suite-filter matching.
 
 ## Workflow Naming Convention
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,18 @@ orchestration around build, test, promotion, and release flows.
   published from `qualcomm-linux/debusine-action`, while the Ubuntu-capable `pkg-builder` images
   are still consumed from GHCR by the local path.
 
+## Package Repo Extra Repositories
+
+- The `build_package` composite action supports an optional
+  `debian/extra-repositories.txt` file in package repositories.
+- Active entries are passed to `sbuild` as `--extra-repository`.
+- Supported entry styles:
+  - global entries (apply to all suites)
+  - suite-filtered entries (for example `[noble,questing] deb ...`)
+  - wildcards (`[all]` or `[*]`)
+- Suite placeholders are expanded at runtime:
+  - `{suite}`, `{SUITE}`, `${suite}`, `${SUITE}`, `@suite@`, `@SUITE@`
+
 ## Workflow Naming Convention
 
 - `pkg-*` workflow names are for package lifecycle flows (`build`, `promote`, `release`, and

--- a/docs/actions/build_package.md
+++ b/docs/actions/build_package.md
@@ -28,7 +28,7 @@ Supported entry forms:
 
 ```text
 # Applies to all suites:
-deb [arch=arm64 signed-by=/etc/apt/keyrings/vendor.gpg] https://repo.example.org/debian {suite} main
+deb [arch=arm64 signed-by=/etc/apt/keyrings/vendor.gpg] https://repo.example.org/debian noble main
 
 # Applies only to specific suites:
 [noble,questing,resolute] deb [arch=arm64 trusted=yes] https://ppa.launchpadcontent.net/example/team/ubuntu noble main
@@ -36,8 +36,8 @@ deb [arch=arm64 signed-by=/etc/apt/keyrings/vendor.gpg] https://repo.example.org
 
 Notes:
 - Lines beginning with `#` and empty lines are ignored.
-- Suite filters support `all` or `*` as wildcards.
-- Suite placeholders are expanded at runtime: `{suite}`, `{SUITE}`, `${suite}`, `${SUITE}`, `@suite@`, `@SUITE@`.
+- Suite filters are exact matches against the build suite.
+- `unstable` and `sid` are treated as equivalent for suite-filter matching.
 
 Example:
 

--- a/docs/actions/build_package.md
+++ b/docs/actions/build_package.md
@@ -13,6 +13,39 @@
 | `build-dir` | Yes | - | Directory where build artifacts will be placed |
 | `run-lintian` | No | `false` | Whether to run lintian quality checks |
 
+## Optional Repo File
+
+If the package repository contains `debian/extra-repositories.txt`, each
+active entry is forwarded to `sbuild` as:
+
+```bash
+--extra-repository "<line>"
+```
+
+This applies to all build modes (source/gbp and prebuilt/native/quilt).
+
+Supported entry forms:
+
+```text
+# Applies to all suites:
+deb [arch=arm64 signed-by=/etc/apt/keyrings/vendor.gpg] https://repo.example.org/debian {suite} main
+
+# Applies only to specific suites:
+[noble,questing,resolute] deb [arch=arm64 trusted=yes] https://ppa.launchpadcontent.net/example/team/ubuntu noble main
+```
+
+Notes:
+- Lines beginning with `#` and empty lines are ignored.
+- Suite filters support `all` or `*` as wildcards.
+- Suite placeholders are expanded at runtime: `{suite}`, `{SUITE}`, `${suite}`, `${SUITE}`, `@suite@`, `@SUITE@`.
+
+Example:
+
+```text
+# Extra dependency repositories for this package
+deb [arch=arm64 signed-by=/etc/apt/keyrings/vendor.gpg] https://ppa.launchpadcontent.net/example/team/ubuntu noble main
+```
+
 ## Process Flow
 
 ```mermaid
@@ -23,11 +56,11 @@ flowchart TD
     D -->|quilt| E[Quilt Format OK]
     D -->|native| F[Native Format OK]
     D -->|unknown| G[Error: Unsupported]
-    E --> H{Check for Extra Repo}
+    E --> H{debian/extra-repositories.txt exists?}
     F --> H
-    H -->|Available| I[Add pkg.qualcomm.com repo]
-    H -->|Not Available| J[Skip Extra Repo]
-    I --> K[Run gbp buildpackage]
+    H -->|Yes| I[Pass each entry as --extra-repository]
+    H -->|No| J[Use default apt repositories only]
+    I --> K[Run sbuild/gbp buildpackage]
     J --> K
     K --> L{Lintian Enabled?}
     L -->|Yes| M[Run with --run-lintian]
@@ -53,15 +86,14 @@ The action determines the build configuration based on the runner architecture:
 The action runs git-buildpackage with sbuild:
 
 ```bash
-gbp buildpackage \
-  --git-ignore-branch \
-  --git-builder="sbuild --host=arm64 \
-                        --build=${BUILD_ARCH} \
-                        --dist=${suite} \
-                        ${lintian_flag} \
-                        --build-dir ../${build-dir} \
-                        --build-dep-resolver=apt \
-                        ${EXTRA_REPO}"
+sbuild --no-clean-source \
+  --host=arm64 \
+  --build=${BUILD_ARCH} \
+  --dist=${suite} \
+  ${lintian_flag} \
+  --build-dir ../${build-dir} \
+  --build-dep-resolver=apt \
+  [--extra-repository "<entry>" ...]
 ```
 
 ## Key Features
@@ -69,7 +101,7 @@ gbp buildpackage \
 - **Cross-compilation support**: Can build ARM64 packages on x86_64 hosts
 - **Native builds**: Can build ARM64 packages on ARM64 hosts (faster)
 - **Chroot isolation**: Uses sbuild with unshare mode for clean builds
-- **Extra repository**: Automatically adds internal Qualcomm repo if available
+- **Extra repositories**: Loads repo-specific entries from `debian/extra-repositories.txt` and passes them via `--extra-repository`
 - **Error handling**: Prints build log tail on failure for debugging
 - **Source format detection**: Supports both quilt and native formats
 


### PR DESCRIPTION
## Summary

Add support for package-repo-provided extra apt repositories during CI builds via an optional `debian/extra-repositories.txt` file.

## Mechanism

`build_package` reads `debian/extra-repositories.txt` (if present) and forwards active entries to `sbuild` as `--extra-repository`.

Supported entry forms:
- Global entry (applies to all suites):
  - `deb ...`
- Suite-filtered entry:
  - `[noble,questing,resolute] deb ...`

Behavior:
- Suite filters are exact matches against the build suite
- `unstable` and `sid` are treated as equivalent for filter matching
- Empty lines and comment lines are ignored
- Active entries are de-duplicated
- Malformed bracketed entries fail fast
- Applies to all sbuild invocation paths in the action:
  - source/gbp path
  - prebuilt native path
  - prebuilt quilt path

## Validation

Validated downstream with `pkg-example` using `qcom-build-utils@development` at commit `fc9b2261e31f5e2cdb816e570698f96efb59d01f`.

Workflow run:
- `pkg-example` build workflow run: https://github.com/qualcomm-linux/pkg-example/actions/runs/27319570199
- Inputs:
  - `debian-ref=qcom/debian/latest`
  - `suite=noble`
  - `force-docker-build=true`

Observed in logs:
- Extra repository file detected and loaded
- Loaded entry: `deb [arch=arm64 trusted=yes] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble main`
- Build-Depends included `python3.7-dev`
- `python3.7-dev` and related packages were pulled from the configured PPA and build completed successfully
