### PR TITLE
rootfs: dependency-resolved --local-debs installation, APT-based kernel delivery, and deferred bootloader update

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -17,7 +17,9 @@
 #   - Supports JSON package manifest for additional package installation
 #     (via apt or local .deb) inside the rootfs.
 #   - Supports injecting custom apt sources from the package manifest.
-#   - Injects custom kernel and firmware .deb packages.
+#   - Optionally injects custom kernel and firmware .deb packages.
+#   - Supports installing local .deb packages (--local-debs) with full dependency resolution
+#     via a temporary local APT repository built inside the rootfs.
 #   - Installs user-specified packages from seed and/or overlay manifest.
 #   - Dynamically deduces and generates base and custom package manifests.
 #   - Configures GRUB bootloader, hostname, DNS, and other system settings.
@@ -27,18 +29,28 @@
 #   ./build-rootfs.sh \
 #     --product-conf qcom-product.conf \
 #     --seed seed_file \
-#     --kernel-package kernel.deb \
+#     [--kernel-package kernel.deb] \
 #     [--firmware firmware.deb] \
 #     [--overlay package-manifest.json] \
-#     [--variant desktop]
+#     [--variant desktop] \
+#     [--local-debs pkg-a.deb] \
+#     [--local-debs debs/]
 #
 # ARGUMENTS:
 #   --product-conf <qcom-product.conf>     Required. Product configuration file.
 #   --seed <seed_file>                     Required. Seed file: one package per line (# comments allowed).
-#   --kernel-package <kernel.deb>          Required. Custom kernel package.
+#   --kernel-package <kernel.deb>          Optional. Custom kernel package.
 #   --firmware <firmware.deb>              Optional. Custom firmware package.
 #   --overlay <package-manifest.json>      Optional. JSON manifest specifying extra packages/apt sources.
 #   --variant <variant_name>               Optional. System variant (default: desktop).
+#   --local-debs <path>                    Optional. A .deb file OR a directory of .deb files to install
+#                                          via a local APT repo (repeatable). May be specified multiple
+#                                          times. Inter-package dependencies are resolved automatically
+#                                          via a temporary local APT repository built inside the rootfs.
+#                                          Installed after manifest packages (--overlay).
+#                                          Examples:
+#                                            --local-debs mypkg.deb
+#                                            --local-debs debs/
 #
 # OUTPUT:
 #   rootfs.img                             Flashable ext4 rootfs image.
@@ -69,21 +81,26 @@ MANIFEST=""          # internal name retained (overlay JSON)
 KERNEL_DEB=""
 FIRMWARE_DEB=""
 VARIANT_INPUT=""     # New variable to hold the variant argument
+LOCAL_DEBS=()        # Array of local .deb file paths (--local-debs, repeatable)
 USE_CONF=0
 USE_MANIFEST=0
 TARGET=""
 
 print_usage() {
     echo "Usage:"
-    echo "  $0 --product-conf <qcom-product.conf> --seed <seed_file> --kernel-package <kernel.deb> [--firmware <firmware.deb>] [--overlay <package-manifest.json>] [--variant <variant>]"
+    echo "  $0 --product-conf <qcom-product.conf> --seed <seed_file> [--kernel-package <kernel.deb>] [--firmware <firmware.deb>] [--overlay <package-manifest.json>] [--variant <variant>] [--local-debs <pkg.deb>] ..."
     echo
     echo "Arguments:"
     echo "  --product-conf   Required. qcom-product.conf"
     echo "  --seed           Required. Seed file (one package per line; supports # comments)"
-    echo "  --kernel-package Required. Kernel .deb"
+    echo "  --kernel-package Optional. Kernel .deb"
     echo "  --firmware       Optional. Firmware .deb"
     echo "  --overlay        Optional. package-manifest.json (same schema as current manifest)"
     echo "  --variant        Optional. System variant (default: desktop)"
+    echo "  --local-debs     Optional. A .deb file OR a directory of .deb files to install via a"
+    echo "                   local APT repo (repeatable). Specify once per path. Dependencies"
+    echo "                   between packages are resolved automatically. Installed after manifest."
+    echo "                   Examples: --local-debs mypkg.deb   --local-debs debs/"
 }
 
 # Parse named options
@@ -102,6 +119,8 @@ while [[ $# -gt 0 ]]; do
             MANIFEST="${2-}"; shift 2 ;;
         --variant)
             VARIANT_INPUT="${2-}"; shift 2 ;;
+        --local-debs)
+            if [[ -n "${2-}" ]]; then LOCAL_DEBS+=("${2-}"); fi; shift 2 ;;
         -h|--help)
             print_usage
             exit 0
@@ -115,7 +134,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Validate required args
-if [[ -z "${CONF}" || -z "${SEED}" || -z "${KERNEL_DEB}" ]]; then
+if [[ -z "${CONF}" || -z "${SEED}" ]]; then
     echo "[ERROR] Missing required argument(s)."
     print_usage
     exit 1
@@ -129,13 +148,25 @@ fi
 
 [[ -f "$CONF" ]] || { echo "[ERROR] Config file not found: $CONF"; exit 1; }
 [[ -f "$SEED" ]] || { echo "[ERROR] Seed file not found: $SEED"; exit 1; }
-[[ -f "$KERNEL_DEB" ]] || { echo "[ERROR] Kernel package not found: $KERNEL_DEB"; exit 1; }
+if [[ -n "$KERNEL_DEB" ]]; then
+    [[ -f "$KERNEL_DEB" ]] || { echo "[ERROR] Kernel package not found: $KERNEL_DEB"; exit 1; }
+fi
 if [[ -n "$FIRMWARE_DEB" ]]; then
     [[ -f "$FIRMWARE_DEB" ]] || { echo "[ERROR] Firmware package not found: $FIRMWARE_DEB"; exit 1; }
 fi
 if [[ "$USE_MANIFEST" -eq 1 && -n "$MANIFEST" ]]; then
     [[ -f "$MANIFEST" ]] || { echo "[ERROR] Manifest/overlay file not found: $MANIFEST"; exit 1; }
 fi
+for _deb in "${LOCAL_DEBS[@]}"; do
+    if [[ -d "$_deb" ]]; then
+        : # directory — may contain zero or more .deb files; handled gracefully at copy time
+    elif [[ -f "$_deb" ]]; then
+        : # valid .deb file path
+    else
+        echo "[ERROR] --local-debs path not found (not a file or directory): $_deb"
+        exit 1
+    fi
+done
 
 WORKDIR=$(pwd)
 MNT_DIR="$WORKDIR/mnt"
@@ -391,7 +422,9 @@ fi
 # Step 4: Inject Kernel, Firmware, and Working resolv.conf
 # ==============================================================================
 echo "[INFO] Copying kernel and firmware packages into rootfs..."
-cp "$KERNEL_DEB" "$ROOTFS_DIR/"
+if [[ -n "$KERNEL_DEB" ]]; then
+    cp "$KERNEL_DEB" "$ROOTFS_DIR/"
+fi
 if [[ -n "$FIRMWARE_DEB" ]]; then
     cp "$FIRMWARE_DEB" "$ROOTFS_DIR/"
 fi
@@ -464,6 +497,27 @@ EOF
 chmod +x "$ROOTFS_DIR/install_manifest_pkgs.sh"
 
 # ==============================================================================
+# Step 6.5: Copy local .deb packages into rootfs (if provided)
+# ==============================================================================
+if [[ ${#LOCAL_DEBS[@]} -gt 0 ]]; then
+    echo "[INFO] Copying local .deb packages into rootfs for local APT repository..."
+    mkdir -p "$ROOTFS_DIR/opt/local-debs"
+    for _deb in "${LOCAL_DEBS[@]}"; do
+        if [[ -d "$_deb" ]]; then
+            echo "[INFO]   -> directory: $_deb"
+            for _f in "$_deb"/*.deb; do
+                [[ -f "$_f" ]] || continue   # skip if glob matched nothing (empty dir)
+                echo "[INFO]      $(basename "$_f")"
+                cp "$_f" "$ROOTFS_DIR/opt/local-debs/"
+            done
+        else
+            echo "[INFO]   -> $(basename "$_deb")"
+            cp "$_deb" "$ROOTFS_DIR/opt/local-debs/"
+        fi
+    done
+fi
+
+# ==============================================================================
 # Step 7: Bind Mount System Directories for chroot
 # ==============================================================================
 echo "[INFO] Binding system directories..."
@@ -516,6 +570,13 @@ else
     CMD_FW_INSTALL="echo '[CHROOT] Skipping firmware installation.'"
 fi
 
+CMD_KERNEL_INSTALL=""
+if [[ -n "$KERNEL_DEB" ]]; then
+    CMD_KERNEL_INSTALL="yes \"\" | dpkg -i /$(basename "$KERNEL_DEB")"
+else
+    CMD_KERNEL_INSTALL="echo '[CHROOT] Skipping kernel installation (no kernel package provided).'"
+fi
+
 echo "[INFO] Entering chroot to install packages and configure GRUB..."
 env DISTRO="$DISTRO" CODENAME="$CODENAME" VARIANT="$VARIANT" \
     chroot "$ROOTFS_DIR" /bin/bash -c "
@@ -562,7 +623,7 @@ dpkg-query -W -f='\${Package} \${Version}\n' > /tmp/\${CODENAME}_base.manifest
 
 echo '[CHROOT] Installing custom firmware and kernel...'
 $CMD_FW_INSTALL
-yes \"\" | dpkg -i /$(basename "$KERNEL_DEB")
+$CMD_KERNEL_INSTALL
 
 # Run update-grub explicitly: the zz-update-grub hook skips it in a chroot
 # because systemd is not running (/run/systemd/system absent).
@@ -574,6 +635,23 @@ usermod -aG sudo qcom
 
 echo '[CHROOT] Installing manifest packages (if any)...'
 /install_manifest_pkgs.sh || true
+
+echo '[CHROOT] Installing local .deb packages via local APT repository (if any)...'
+if ls /opt/local-debs/*.deb >/dev/null 2>&1; then
+    echo '[CHROOT] Setting up local .deb APT repository...'
+    apt-get install -y --no-install-recommends dpkg-dev
+    cd /opt/local-debs
+    dpkg-scanpackages . /dev/null > Packages
+    cd /
+    echo 'deb [trusted=yes] file:///opt/local-debs ./' > /etc/apt/sources.list.d/local-debs.list
+    apt-get update
+    LOCAL_PKG_NAMES=\$(for deb in /opt/local-debs/*.deb; do dpkg-deb --field \"\$deb\" Package; done | tr '\n' ' ')
+    echo \"[CHROOT] Installing local packages: \$LOCAL_PKG_NAMES\"
+    apt-get install -y \$LOCAL_PKG_NAMES
+    echo '[CHROOT] Local .deb packages installed successfully.'
+else
+    echo '[CHROOT] No local .deb packages found; skipping.'
+fi
 
 echo '[CHROOT] Capturing post-install package list...'
 dpkg-query -W -f='\${Package} \${Version}\n' > /tmp/\${CODENAME}_post.manifest

--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -139,7 +139,7 @@ fi
 
 WORKDIR=$(pwd)
 MNT_DIR="$WORKDIR/mnt"
-ROOTFS_DIR="$WORKDIR/rootfs"
+ROOTFS_DIR="$WORKDIR/rootfs_work"
 ROOTFS_IMG="rootfs.img"
 mkdir -p "$MNT_DIR" "$ROOTFS_DIR"
 

--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -18,6 +18,8 @@
 #     (via apt or local .deb) inside the rootfs.
 #   - Supports injecting custom apt sources from the package manifest.
 #   - Optionally injects custom kernel and firmware .deb packages.
+#   - Supports installing kernel packages via APT through the --overlay manifest
+#     (source: apt); update-grub runs after all installs regardless of kernel path.
 #   - Supports installing local .deb packages (--local-debs) with full dependency resolution
 #     via a temporary local APT repository built inside the rootfs.
 #   - Installs user-specified packages from seed and/or overlay manifest.
@@ -625,10 +627,6 @@ echo '[CHROOT] Installing custom firmware and kernel...'
 $CMD_FW_INSTALL
 $CMD_KERNEL_INSTALL
 
-# Run update-grub explicitly: the zz-update-grub hook skips it in a chroot
-# because systemd is not running (/run/systemd/system absent).
-update-grub
-
 adduser --disabled-password --gecos '' qcom
 echo 'qcom:qcom' | chpasswd
 usermod -aG sudo qcom
@@ -653,20 +651,15 @@ else
     echo '[CHROOT] No local .deb packages found; skipping.'
 fi
 
-echo '[CHROOT] Capturing post-install package list...'
-dpkg-query -W -f='\${Package} \${Version}\n' > /tmp/\${CODENAME}_post.manifest
-
-echo '[CHROOT] Sorting and computing package delta...'
-sort /tmp/\${CODENAME}_base.manifest > /tmp/sorted_base.manifest
-sort /tmp/\${CODENAME}_post.manifest > /tmp/sorted_post.manifest
-DATE=\$(date +%Y-%m-%d)
-comm -13 /tmp/sorted_base.manifest /tmp/sorted_post.manifest > /tmp/packages_\${DATE}.manifest
-
-echo '[CHROOT] Cleaning up intermediate files...'
-rm -f /tmp/\${CODENAME}_post.manifest /tmp/sorted_base.manifest /tmp/sorted_post.manifest
-
-echo '[CHROOT] Base package list preserved as /tmp/\${CODENAME}_base.manifest'
-echo '[CHROOT] Custom installed packages saved to /tmp/packages_\${DATE}.manifest'
+# ==============================================================================
+# Run update-grub after ALL installs (firmware, kernel via dpkg or apt, manifest,
+# local-debs). This ensures GRUB sees whichever kernel was installed last,
+# regardless of the delivery path.
+# The zz-update-grub hook skips update-grub in a chroot because systemd is not
+# running (/run/systemd/system absent), so we call it explicitly here.
+# ==============================================================================
+echo '[CHROOT] Running update-grub after all package installs...'
+update-grub
 
 # ==============================================================================
 # GRUB Configuration Cleanup & Standardization
@@ -686,27 +679,43 @@ sed -i 's/root=\/dev\/[^ ]* //g' /boot/grub/grub.cfg
 # Device Tree Configuration for Debian platforms
 # ==============================================================================
 
-if [ \"\${distro_lc}\" = \"debian\" ]; then
+if [ "\${distro_lc}" = "debian" ]; then
     echo '[INFO][CHROOT] Debian target detected. Configuring platform Device Tree...'
 
     # Locate the platform Device Tree Blob (DTB) in standard library or firmware paths
-    DTB_PATH=\$(find /usr/lib /lib/firmware -name \"glymur-crd.dtb\" -print -quit)
+    DTB_PATH=\$(find /usr/lib /lib/firmware -name "glymur-crd.dtb" -print -quit)
 
-    if [ -n \"\$DTB_PATH\" ]; then
-        echo \"[INFO][CHROOT] Platform DTB resolved: \$DTB_PATH\"
+    if [ -n "\$DTB_PATH" ]; then
+        echo "[INFO][CHROOT] Platform DTB resolved: \$DTB_PATH"
         
         # Ensure DTB is accessible in the bootloader's filesystem scope
-        ln -sf \"\$DTB_PATH\" /boot/dtb
+        ln -sf "\$DTB_PATH" /boot/dtb
         
         # Inject the devicetree directive into the generated GRUB configuration.
         # This appends the command immediately following the 'initrd' load.
-        sed -i \"/^[[:space:]]*initrd/a \    devicetree /boot/dtb\" /boot/grub/grub.cfg
+        sed -i "/^[[:space:]]*initrd/a \    devicetree /boot/dtb" /boot/grub/grub.cfg
         
         echo '[SUCCESS][CHROOT] Device Tree directive injected into /boot/grub/grub.cfg'
     else
         echo '[WARN][CHROOT] Target DTB (glymur-crd.dtb) not found. Skipping injection.'
     fi
 fi
+
+echo '[CHROOT] Capturing post-install package list...'
+dpkg-query -W -f='\${Package} \${Version}\n' > /tmp/\${CODENAME}_post.manifest
+
+echo '[CHROOT] Sorting and computing package delta...'
+sort /tmp/\${CODENAME}_base.manifest > /tmp/sorted_base.manifest
+sort /tmp/\${CODENAME}_post.manifest > /tmp/sorted_post.manifest
+DATE=\$(date +%Y-%m-%d)
+comm -13 /tmp/sorted_base.manifest /tmp/sorted_post.manifest > /tmp/packages_\${DATE}.manifest
+
+echo '[CHROOT] Cleaning up intermediate files...'
+rm -f /tmp/\${CODENAME}_post.manifest /tmp/sorted_base.manifest /tmp/sorted_post.manifest
+
+echo '[CHROOT] Base package list preserved as /tmp/\${CODENAME}_base.manifest'
+echo '[CHROOT] Custom installed packages saved to /tmp/packages_\${DATE}.manifest'
+
 "
 
 # ==============================================================================

--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -675,32 +675,6 @@ sed -i 's/search --no-floppy --fs-uuid --set=root .*/search --no-floppy --label 
 # conflicts with our 'root=LABEL=system' argument.
 sed -i 's/root=\/dev\/[^ ]* //g' /boot/grub/grub.cfg
 
-# ==============================================================================
-# Device Tree Configuration for Debian platforms
-# ==============================================================================
-
-if [ "\${distro_lc}" = "debian" ]; then
-    echo '[INFO][CHROOT] Debian target detected. Configuring platform Device Tree...'
-
-    # Locate the platform Device Tree Blob (DTB) in standard library or firmware paths
-    DTB_PATH=\$(find /usr/lib /lib/firmware -name "glymur-crd.dtb" -print -quit)
-
-    if [ -n "\$DTB_PATH" ]; then
-        echo "[INFO][CHROOT] Platform DTB resolved: \$DTB_PATH"
-        
-        # Ensure DTB is accessible in the bootloader's filesystem scope
-        ln -sf "\$DTB_PATH" /boot/dtb
-        
-        # Inject the devicetree directive into the generated GRUB configuration.
-        # This appends the command immediately following the 'initrd' load.
-        sed -i "/^[[:space:]]*initrd/a \    devicetree /boot/dtb" /boot/grub/grub.cfg
-        
-        echo '[SUCCESS][CHROOT] Device Tree directive injected into /boot/grub/grub.cfg'
-    else
-        echo '[WARN][CHROOT] Target DTB (glymur-crd.dtb) not found. Skipping injection.'
-    fi
-fi
-
 echo '[CHROOT] Capturing post-install package list...'
 dpkg-query -W -f='\${Package} \${Version}\n' > /tmp/\${CODENAME}_post.manifest
 


### PR DESCRIPTION
## Summary

`build-rootfs.sh` gains a dependency-resolving install path for locally built `.deb` packages (`--local-debs`), drops the hard requirement on `--kernel-package`, and defers `update-grub` until every package-delivery path has completed. With these changes the kernel can arrive via any of three routes: direct deb (`--kernel-package`), overlay-manifest APT source (`--overlay`), or a staged local APT repository (`--local-debs`). In all cases the generated bootloader configuration reflects the final installed package set, regardless of which route delivered the kernel.

Two supporting changes complete the PR: a workspace-isolation fix that makes the script safe to invoke repeatedly from the same checkout (required for multi-kernel CI loops), and removal of a board-specific DTB/GRUB mutation that did not belong in this distribution-agnostic tool.

Primary consumer: the multi-kernel distro pipeline in [qcom-distro-images #84](https://github.com/qualcomm-linux/qcom-distro-images/pull/84), which invokes this script once per kernel variant.

## Why

Four independent problems, fixed in four scoped commits:

1. Kernel ingestion was rigid and did not resolve dependencies. `--kernel-package` was mandatory, blocking flows where the kernel comes from APT or overlay manifests. Plain `dpkg -i` cannot resolve dependency graphs, which is a problem for kernel package sets that span multiple debs (for example canonical-layout kernels split across `linux-image-*` and `linux-modules-*` with inter-package dependencies).
2. `update-grub` ran too early. It executed immediately after the direct kernel `dpkg -i`, before overlay-manifest and local-debs installs. When the effective kernel arrives through one of those later paths, GRUB was generated against stale kernel state.
3. The script could delete itself. `ROOTFS_DIR` was `$WORKDIR/rootfs`, which collides with the repository's own `rootfs/` source directory when invoked from the repo root. The preprocessing stage's `rm -rf "$ROOTFS_DIR"` could remove `rootfs/scripts/build-rootfs.sh` mid-run, which breaks any loop that calls the script more than once per workspace.
4. Board policy in a generic tool. A Debian-only block probed for `glymur-crd.dtb`, symlinked it to `/boot/dtb`, and injected a `devicetree` directive into `grub.cfg`. That is platform-specific boot policy hardcoded into shared rootfs assembly.

## What changed (one commit per concern)

### 1. `rootfs: isolate build workspace from source tree` (dd57d03)
Runtime extraction/build directory renamed from `$WORKDIR/rootfs` to `$WORKDIR/rootfs_work`. The generated-state directory and the checked-in source directory no longer share a path, so repeated invocations in a single CI job can no longer destroy the script sources. Path-safety fix only; no other behavior change.

### 2. `rootfs: add local-debs flow; kernel deb optional` (5dd6591)
New repeatable CLI option `--local-debs <path>`:
- accepts a `.deb` file or a directory of `.deb` files, and may be given multiple times,
- validates every path up front (hard error on a nonexistent path; empty directories tolerated),
- stages all discovered debs into `/opt/local-debs` inside the rootfs.

Inside the chroot a throwaway local APT repository is built from the staged debs:
1. install `dpkg-dev` (`--no-install-recommends`),
2. generate the index with `dpkg-scanpackages . /dev/null > Packages`,
3. register `deb [trusted=yes] file:///opt/local-debs ./` in `sources.list.d/local-debs.list`,
4. extract package names from deb metadata (`dpkg-deb --field <deb> Package`),
5. `apt-get install -y <names>`, so APT computes the install order and satisfies inter-package dependencies across the provided set and the configured remote sources.

Why an APT repository instead of `dpkg -i`: `dpkg -i` installs exactly what it is handed and fails on unmet dependencies. The local-repo approach lets APT resolve dependency chains (for example `linux-image` and `linux-modules`) deterministically.

In the same commit, `--kernel-package` becomes optional, with conditional validation, copy, and install (a skip message when absent). `--product-conf` and `--seed` remain the only required arguments. With no `--local-debs`, every local-repo stage is a no-op.

### 3. `rootfs: run update-grub after all package installs` (35cdcac)
`update-grub` (and the subsequent grub.cfg normalization and manifest-delta capture) moves from immediately after the kernel `dpkg -i` to after all install sources complete. The explicit invocation is kept because the `zz-update-grub` kernel hook skips itself in a chroot (no `/run/systemd/system`). The bootloader state now reflects whichever kernel was installed last, and the kernel delivery path no longer changes GRUB correctness.

### 4. `rootfs: drop Debian-specific DTB injection` (dc80c48)
Removes the `glymur-crd.dtb` probe, the `/boot/dtb` symlink, and the `grub.cfg` `devicetree` injection. DTB and boot policy belong to the target-specific layers that own board behavior (in the distro pipeline, FIT DTB generation is handled per kernel variant by qcom-distro-images CI), not to the generic image builder.

## Install sequence inside the chroot (after this PR)

1. Capture base package manifest.
2. Firmware `dpkg -i` (if `--firmware`).
3. Kernel `dpkg -i` (if `--kernel-package`).
4. User and account setup.
5. Overlay manifest packages: APT sources and listed packages (if `--overlay`).
6. Local-debs packages via the local APT repository (if `--local-debs`).
7. `update-grub`, explicit, after all installs.
8. grub.cfg normalization (`search --label system`, strip `root=/dev/*`).
9. Post-install manifest capture and base/post delta.

## CLI contract

| Argument | Before | After |
|---|---|---|
| `--product-conf` | required | required |
| `--seed` | required | required |
| `--kernel-package` | required | optional |
| `--firmware` | optional | optional |
| `--overlay` | optional | optional |
| `--variant` | optional | optional |
| `--local-debs` | n/a | new, optional, repeatable (file or directory) |

## Compatibility

- Existing callers are unaffected: passing `--kernel-package` works exactly as before, and the new behavior is opt-in.
- `update-grub` timing: for callers whose kernel arrives only via `--kernel-package` (and whose overlays do not install kernels), the resulting `grub.cfg` is identical; it is simply generated later. For overlay or local-debs delivered kernels, the previous behavior was incorrect and is now fixed.
- The DTB injection removal is a deliberate behavioral change for Debian targets that relied on the injected `devicetree` directive. The only consumer (trixie/generic) is retired from the nightly matrix in [qcom-distro-images #84](https://github.com/qualcomm-linux/qcom-distro-images/pull/84); board DTB policy is now owned by target-specific layers.

## Known trade-off (candidate follow-up)

The staged debs under `/opt/local-debs` and the `local-debs.list` APT source entry remain in the shipped image (the index stays self-consistent, so on-device `apt update` keeps working). This mirrors the existing behavior of the kernel deb being copied to `/` and left there, but it does add image payload. A cleanup pass (remove staged debs and the source entry after install) is a reasonable follow-up.

## Files changed

- `rootfs/scripts/build-rootfs.sh` (+111/-50)

## Validation

- Static: `bash -n rootfs/scripts/build-rootfs.sh`.
- End to end: the validation sweep on [qcom-distro-images #84](https://github.com/qualcomm-linux/qcom-distro-images/pull/84) was dispatched with `qcom-build-utils-ref=feat/rootfs-local-debs-overlay-kernel-bootflow`. Every rootfs in those runs was assembled by this script, covering both the single-deb qcom-next closure and the multi-deb canonical closure (`linux-image` plus `linux-modules` resolved by APT), across latest and pinned modes and server and desktop matrix targets. 
