### PR TITLE
pkg-pr-hook: skip on forks and the template repo

### DIFF
--- a/.github/pkg-workflows/debian/pkg-pr-hook.yml
+++ b/.github/pkg-workflows/debian/pkg-pr-hook.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   resolve-suite:
     name: Resolve suite from branch
+    if: github.repository_owner == 'qualcomm-linux' && github.repository != 'qualcomm-linux/pkg-template'
     runs-on: ubuntu-latest
     outputs:
       suite: ${{ steps.resolve.outputs.suite }}


### PR DESCRIPTION
The PR build workflow on qcom/debian/latest fires on every PR
targeting qcom/** branches, but it can only succeed on real pkg-*
repos under qualcomm-linux. Running it on the pkg-template repo
itself (where the debian/ files are placeholders) or on personal
forks (where required secrets aren't available) just produces red
checks with no signal.

Add a repo guard to the entry-point job so the workflow only runs
on qualcomm-linux/pkg-* repos other than pkg-template.
