### PR TITLE
Update workflows_sync.yml

### DIFF
--- a/.github/workflows/workflows_sync.yml
+++ b/.github/workflows/workflows_sync.yml
@@ -49,8 +49,8 @@ jobs:
                          "pkg-kernel-fedora" \
                          "pkg-linux-kernel" \
                          "pkg-workspace" \
-                         "pkg-ynancher" \
-                         "pkg-linux-qcom-backup" )
+                         "pkg-linux-qcom" \
+                         "pkg-linux-qcom-canonical" )
 
           # Array to store created PR URLs
           PR_URLS=()


### PR DESCRIPTION
Add 
- pkg-linux-qcom
- pkg-linux-qcom-canonical to the exclude list of workflow_sync packages while removing pkg-ynancher