### PR TITLE
pkg-release: include run_attempt in S3 proposed upload path

### DIFF
--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -670,7 +670,7 @@ jobs:
         with:
           s3_bucket: qli-prd-lecore-gh-artifacts
           path: s3-provenance
-          destination: qualcomm-linux/pkg/proposed/${{ github.run_id }}/
+          destination: qualcomm-linux/pkg/proposed/${{ github.run_id }}-${{ github.run_attempt }}/
 
   upload-debs-to-s3:
     name: Upload Debs to S3 (Ubuntu)
@@ -707,4 +707,4 @@ jobs:
         with:
           s3_bucket: qli-prd-lecore-gh-artifacts
           path: s3-proposed
-          destination: qualcomm-linux/pkg/proposed/${{ github.run_id }}/
+          destination: qualcomm-linux/pkg/proposed/${{ github.run_id }}-${{ github.run_attempt }}/


### PR DESCRIPTION
## Summary

Use `<run_id>-<run_attempt>` as the S3 key instead of `<run_id>` alone for the proposed debs and provenance uploads.

Without `run_attempt`, re-runs of the same workflow overwrite the previous attempt's artifacts at the same S3 path, making it impossible to distinguish or audit them.

## S3 layout

```
s3://qli-prd-lecore-gh-artifacts/qualcomm-linux/pkg/proposed/<run_id>-<run_attempt>/
  provenance_<suite>.json
  debs/
    *.deb
```