### PR TITLE
pkg-release: add pkg_repo_branch to provenance.json

### DIFF
--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -523,6 +523,7 @@ jobs:
           PKG_VERSION: ${{ needs.build-and-test.outputs.srcpkg_version }}
           PKG_REPO: ${{ github.repository }}
           SRCPKG_NAME: ${{ needs.build-and-test.outputs.srcpkg_name }}
+          PKG_REPO_BRANCH: ${{ needs.prepare-release-source.outputs.branch_ref }}
         run: |
           set -euxo pipefail
 
@@ -561,6 +562,7 @@ jobs:
               "pkg_repo": "${PKG_REPO}",
               "pkg_repo_tag": "$PACKAGE_REPO_TAG",
               "pkg_repo_commit": "$PACKAGE_REPO_COMMIT",
+              "pkg_repo_branch": "${PKG_REPO_BRANCH}",
 
               "binary_pkgs": $ALL_PKGS_JSON
             }
@@ -592,6 +594,7 @@ jobs:
               "pkg_repo": "${PKG_REPO}",
               "pkg_repo_tag": "$PACKAGE_REPO_TAG",
               "pkg_repo_commit": "$PACKAGE_REPO_COMMIT",
+              "pkg_repo_branch": "${PKG_REPO_BRANCH}",
               "pkg_repo_upstream_tag": "$NEAREST_UPSTREAM_BRANCH_TAG",
 
               "binary_pkgs": $ALL_PKGS_JSON


### PR DESCRIPTION
## Summary

Add `pkg_repo_branch` to the provenance.json constructed by the `persistance` job.

## Changes

- Added `PKG_REPO_BRANCH` env var to the `Create provenance file` step, sourced from `prepare-release-source.outputs.branch_ref` (the normalized debian branch, e.g. `qcom/ubuntu/resolute`)
- Added `"pkg_repo_branch"` field to both the prebuilt binary and source package provenance blocks
