### PR TITLE
release: push Ubuntu git state after publish

### DIFF
--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -384,26 +384,6 @@ jobs:
 
           git log --graph --oneline -n 10 --color=always
 
-      - name: Push release git state
-        working-directory: ./package-repo
-        env:
-          GH_PAT: ${{ secrets.PAT }}
-          DEBIAN_BRANCH: ${{ needs.prepare-release-source.outputs.branch_ref }}
-          DISTRO_CODENAME: ${{ needs.build-and-test.outputs.suite }}
-          RELEASE_VERSION: ${{ needs.prepare-release-source.outputs.release_version }}
-        run: |
-          set -euxo pipefail
-
-          tag_name="${DISTRO_CODENAME}/${RELEASE_VERSION}"
-          git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${{ github.repository }}.git"
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${tag_name}" >/dev/null; then
-            echo "Error: remote tag '${tag_name}' already exists" >&2
-            exit 1
-          fi
-
-          git push --atomic origin "HEAD:${DEBIAN_BRANCH}" "${tag_name}"
-
       - name: Download Docker build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -479,6 +459,26 @@ jobs:
               "workflow": "${{ steps.pre-upload.outputs.workflow_url }}"
             }
           debug: ${{ inputs.test-run }}
+
+      - name: Push release git state
+        working-directory: ./package-repo
+        env:
+          GH_PAT: ${{ secrets.PAT }}
+          DEBIAN_BRANCH: ${{ needs.prepare-release-source.outputs.branch_ref }}
+          DISTRO_CODENAME: ${{ needs.build-and-test.outputs.suite }}
+          RELEASE_VERSION: ${{ needs.prepare-release-source.outputs.release_version }}
+        run: |
+          set -euxo pipefail
+
+          tag_name="${DISTRO_CODENAME}/${RELEASE_VERSION}"
+          git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${{ github.repository }}.git"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag_name}" >/dev/null; then
+            echo "Error: remote tag '${tag_name}' already exists" >&2
+            exit 1
+          fi
+
+          git push --atomic origin "HEAD:${DEBIAN_BRANCH}" "${tag_name}"
 
   persistance:
     name: Release Metadata Persistence

--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -343,47 +343,6 @@ jobs:
           export DEBFULLNAME="${BOT_NAME}"
           export DEBEMAIL="${BOT_EMAIL}"
 
-      - name: Commit changelog suite change
-        working-directory: ./package-repo
-        env:
-          RELEASE_VERSION: ${{ needs.prepare-release-source.outputs.release_version }}
-          DISTRO_CODENAME: ${{ needs.build-and-test.outputs.suite }}
-          BOT_NAME: ${{ vars.DEB_PKG_BOT_CI_NAME }}
-          BOT_EMAIL: ${{ vars.DEB_PKG_BOT_CI_EMAIL }}
-        run: |
-          set -euxo pipefail
-
-          export DEBFULLNAME="${BOT_NAME}"
-          export DEBEMAIL="${BOT_EMAIL}"
-
-          version=$(dpkg-parsechangelog --show-field Version)
-          if [[ "${version}" != "${RELEASE_VERSION}" ]]; then
-            echo "Error: expected release changelog version '${RELEASE_VERSION}', found '${version}'" >&2
-            exit 1
-          fi
-
-          if [[ "$version" != *-* ]]; then
-            echo "Error: version '$version' has no debian revision part" >&2
-            exit 1
-          fi
-
-          upstream="${version%-*}"
-          rev="${version##*-}"
-
-          if ! [[ "$rev" =~ ^[0-9]+$ ]]; then
-            echo "Error: debian revision '$rev' is not numeric" >&2
-            exit 1
-          fi
-
-          rev=$((rev + 1))
-          newversion="${upstream}-${rev}~"
-          echo "Bumped version -> ${newversion}"
-          dch --newversion="${newversion}" --distribution=UNRELEASED --controlmaint "WIP — update changelog before next release"
-
-          git commit -a -m "debian/changelog: bump to ${newversion}"
-
-          git log --graph --oneline -n 10 --color=always
-
       - name: Download Docker build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -459,6 +418,46 @@ jobs:
               "workflow": "${{ steps.pre-upload.outputs.workflow_url }}"
             }
           debug: ${{ inputs.test-run }}
+
+      - name: Commit next UNRELEASED changelog bump
+        working-directory: ./package-repo
+        env:
+          RELEASE_VERSION: ${{ needs.prepare-release-source.outputs.release_version }}
+          BOT_NAME: ${{ vars.DEB_PKG_BOT_CI_NAME }}
+          BOT_EMAIL: ${{ vars.DEB_PKG_BOT_CI_EMAIL }}
+        run: |
+          set -euxo pipefail
+
+          export DEBFULLNAME="${BOT_NAME}"
+          export DEBEMAIL="${BOT_EMAIL}"
+
+          version=$(dpkg-parsechangelog --show-field Version)
+          if [[ "${version}" != "${RELEASE_VERSION}" ]]; then
+            echo "Error: expected release changelog version '${RELEASE_VERSION}', found '${version}'" >&2
+            exit 1
+          fi
+
+          if [[ "$version" != *-* ]]; then
+            echo "Error: version '$version' has no debian revision part" >&2
+            exit 1
+          fi
+
+          upstream="${version%-*}"
+          rev="${version##*-}"
+
+          if ! [[ "$rev" =~ ^[0-9]+$ ]]; then
+            echo "Error: debian revision '$rev' is not numeric" >&2
+            exit 1
+          fi
+
+          rev=$((rev + 1))
+          newversion="${upstream}-${rev}~"
+          echo "Bumped version -> ${newversion}"
+          dch --newversion="${newversion}" --distribution=UNRELEASED --controlmaint "WIP — update changelog before next release"
+
+          git commit -a -m "debian/changelog: bump to ${newversion}"
+
+          git log --graph --oneline -n 10 --color=always
 
       - name: Push release git state
         working-directory: ./package-repo


### PR DESCRIPTION
## Summary
- move Ubuntu release git push (branch + tag) to run after apt-artifactory upload
- keep Debian release ordering unchanged (publish first, then push git state)

## Why
- prevents persisting package-repo git release state when Ubuntu artifact publish fails

## Validation
- parsed `.github/workflows/pkg-release-reusable-workflow.yml` successfully
