### PR TITLE
release: harden approval environment validation

### DIFF
--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -108,6 +108,42 @@ jobs:
           echo "suite=$suite" >> "$GITHUB_OUTPUT"
           echo "normalized_ref=$normalized_ref" >> "$GITHUB_OUTPUT"
 
+      - name: Validate pkg-release-approval environment
+        if: ${{ steps.resolve.outputs.family == 'ubuntu' || !inputs.test-run }}
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+          REPO: ${{ github.repository }}
+          ENV_NAME: pkg-release-approval
+        run: |
+          set -euo pipefail
+
+          response_json=$(mktemp)
+          http_code=$(curl -sS -o "$response_json" -w "%{http_code}" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/environments/${ENV_NAME}")
+
+          if [[ "$http_code" == "404" ]]; then
+            echo "::error::Environment '${ENV_NAME}' does not exist in '${REPO}'. Create it with at least one required reviewer before releasing."
+            exit 1
+          fi
+
+          if [[ "$http_code" != "200" ]]; then
+            echo "::error::Unexpected HTTP ${http_code} while checking environment '${ENV_NAME}'."
+            cat "$response_json"
+            exit 1
+          fi
+
+          required_reviewer_count=$(python3 -c 'import json,sys; payload=json.load(open(sys.argv[1], encoding="utf-8")); print(sum(len(rule.get("reviewers", [])) for rule in payload.get("protection_rules", []) if rule.get("type") == "required_reviewers"))' "$response_json")
+
+          if [[ "$required_reviewer_count" -eq 0 ]]; then
+            echo "::error::Environment '${ENV_NAME}' exists but has no required reviewers configured. Add at least one required reviewer before releasing."
+            exit 1
+          fi
+
+          echo "::notice::Environment '${ENV_NAME}' is configured with ${required_reviewer_count} required reviewer(s)."
+
       - name: Install packaging tools
         run: |
           set -euxo pipefail


### PR DESCRIPTION
## Description
This PR updates the reusable release workflow to strengthen the approval environment gate.

## Changes
- enforce the `pkg-release-approval` environment check before release proceeds
- remove explicit permissions from `prepare-release-source` that are no longer needed

## Type of Change
- Bug fix (non-breaking change which fixes an issue)

## Additional Context
`pkg-example` targets `qcom-build-utils@development` for downstream validation while this is under review.

