### PR TITLE
release: remove test checkbox and enforce lintian

### DIFF
--- a/.github/pkg-workflows/qli-ci/pkg-release.yml
+++ b/.github/pkg-workflows/qli-ci/pkg-release.yml
@@ -2,22 +2,15 @@ name: Release
 description: |
   Release a new package version.
   This workflow is manually triggered via workflow_dispatch.
+  Set repository variable IS_TEST_PKG=1 to run in test mode.
 
 on:
   workflow_dispatch:
     inputs:
-
       debian-branch:
         description: The debian branch to release. For example branch "qcom/debian/trixie"
         type: string
         required: true
-
-      test-run:
-        description: |
-          Debian: if true, stop after build/test.
-          Ubuntu: still runs the full release flow.
-        type: boolean
-        default: true
 
 permissions:
   contents: write
@@ -29,7 +22,7 @@ jobs:
     with:
       qcom-build-utils-ref: main
       debian-branch: ${{ github.event.inputs.debian-branch }}
-      test-run: ${{ github.event.inputs.test-run == 'true' && true || false }}
+      test-run: ${{ vars.IS_TEST_PKG == '1' || vars.IS_TEST_PKG == 'true' || vars['is-test-pkg'] == '1' || vars['is-test-pkg'] == 'true' }}
       debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
     secrets:
       PAT: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}

--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -257,6 +257,7 @@ jobs:
     with:
       qcom-build-utils-ref: ${{ inputs.qcom-build-utils-ref }}
       debian-ref: ${{ inputs.debian-branch }}
+      run-lintian: true
       release: true
       debusine-parent-workspace: ${{ inputs.debusine-parent-workspace }}
     secrets:

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -177,7 +177,7 @@ reusable workflow: split on `/`, take the last two fields as
 ### Workflow Steps
 
 1. **Prepare release source**: For Ubuntu branches, finalize changelog and create local release commit/tag, then upload the prepared git repo as an artifact
-2. **Build and test once**: Reuse `pkg-build-reusable-workflow` (`release=true`) with `debian-branch` as the build source ref
+2. **Build and test once**: Reuse `pkg-build-reusable-workflow` (`release=true`, `run-lintian=true`) with `debian-branch` as the build source ref
 3. **Environment gate + provenance file**: Require `pkg-release-approval` after build/test and generate provenance from the exact built source state
 4. **Debian release path**: For Debian and `test-run=false`, publish Debusine CI workspace to prod, push git state, then publish provenance
 5. **Ubuntu release path**: Push git state atomically (branch + tag), publish provenance, and upload previously-built Docker artifacts to S3


### PR DESCRIPTION
## Summary
This PR removes the manual release test checkbox, keeps the test capability for designated repos, and makes lintian execution explicit in the release path.

## Changes
- Remove the `test-run` input from the manual dispatch release template (`.github/pkg-workflows/qli-ci/pkg-release.yml`).
- Drive `test-run` from a repo variable instead of UI input:
  - `IS_TEST_PKG=1` (or `true`) -> behaves like the old checkbox being checked.
  - unset/other value -> normal release behavior.
- Enforce `run-lintian: true` in `pkg-release-reusable-workflow.yml` when invoking `pkg-build-reusable-workflow.yml`.
- Update reusable workflow docs to reflect lintian enforcement during release build-and-test.

## Why
- Most users no longer see or need a potentially confusing test checkbox in release UI.
- Test-only repos (such as `pkg-example`) can still run release flows in test mode via a repo-level variable.
- Lintian is guaranteed for release build-and-test, rather than relying on implicit defaults.

## Validation
- YAML parsing check passed for updated workflow files (`python3` + `yaml.safe_load`).
- `git diff --check` passed.

## Expected behavior impact
- Manual release dispatch in callers using the `qli-ci/pkg-release.yml` template no longer asks for `test-run`.
- In repos with `IS_TEST_PKG=1`, release dispatch runs with `test-run=true` behavior.
- Release build-and-test always runs with lintian enabled.
