### PR TITLE
build: accept debusine output via GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -327,8 +327,20 @@ jobs:
         run: |
           set -euxo pipefail
           debusine-action/lib/build
-          cat output >> "$GITHUB_OUTPUT"
-          workspace=$(sed -n 's/^workspace=//p' output)
+
+          # debusine-action/lib/build now writes directly to $GITHUB_OUTPUT.
+          # Keep compatibility with older behavior that wrote a local "output" file.
+          workspace="$(sed -n 's/^workspace=//p' "$GITHUB_OUTPUT" | tail -n 1 || true)"
+          if [[ -z "${workspace}" && -f output ]]; then
+            cat output >> "$GITHUB_OUTPUT"
+            workspace="$(sed -n 's/^workspace=//p' output | tail -n 1 || true)"
+          fi
+
+          if [[ -z "${workspace}" ]]; then
+            echo "::error::Unable to determine Debusine workspace from build outputs."
+            exit 1
+          fi
+
           echo "workspace_url=https://${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${workspace}/" >> "$GITHUB_OUTPUT"
 
       - name: Note Debusine workspace URL


### PR DESCRIPTION
qcom-build-utils expected debusine-action/lib/build to create a local output file and then ran cat output.

debusine-action now writes outputs to $GITHUB_OUTPUT. That left no local output file and Debian builds failed after a successful Debusine run.

Support both formats: read workspace from $GITHUB_OUTPUT first, fall back to the legacy output file, and fail clearly if neither format is present.