### PR TITLE
promote: handle annotated upstream tags

### DIFF
--- a/scripts/merge_debian_packaging_upstream
+++ b/scripts/merge_debian_packaging_upstream
@@ -36,7 +36,12 @@ esac
 
 echo "Merging upstream changes from upstream tag $upstream into Debian packaging branch $debian_branch"
 
-git checkout "$upstream"
+if ! upstream_commit="$(git rev-parse --verify "$upstream^{commit}" 2>/dev/null)"; then
+    echo "Could not resolve upstream input '$upstream' to a commit" >&2
+    exit 3
+fi
+
+git checkout "$upstream_commit"
 git reset "$debian_ref" -- :/:debian :/:.github
 tree=$(git write-tree)
 
@@ -61,7 +66,7 @@ EOF
 
 merge_commit_signoff="Signed-off-by: $(git config user.name) <$(git config user.email)>"
 
-commit=$(git commit-tree -p "$debian_ref" -p "$upstream" -m "$merge_commit_header" -m "$merge_commit_body" -m "$merge_commit_signoff" "$tree")
+commit=$(git commit-tree -p "$debian_ref" -p "$upstream_commit" -m "$merge_commit_header" -m "$merge_commit_body" -m "$merge_commit_signoff" "$tree")
 git reset --hard
 git checkout "$debian_branch"
 git reset --hard "$commit"


### PR DESCRIPTION
## Summary
- Fix `scripts/merge_debian_packaging_upstream` so promotion works when the
  upstream input is an annotated tag.
- This addresses failures seen in `pkg-urm-ext` promotion of `v0.3.9`.

## Root Cause
- The helper accepted an upstream "commit-ish" but passed the raw input
  directly to `git commit-tree -p`.
- For annotated tags, that raw ref resolves to a `tag` object, not a commit
  object.
- `git commit-tree -p` requires commit parents, so promotion failed with:
  `fatal: <sha> is not a valid 'commit' object`.

## Fix
- Resolve the input to a commit with:
  `git rev-parse --verify "$upstream^{commit}"`
- Use that peeled commit for:
  - checkout of upstream content
  - second parent passed to `git commit-tree`

## Why this is safe
- Branches and lightweight tags already resolve to commits and keep the same
  behavior.
- Annotated tags now follow the intended flow instead of failing.

## Validation
- Reproduced the failure path locally against `pkg-urm-ext` on
  `qcom/ubuntu/resolute` with upstream tag `v0.3.9`.
- After this change, the same merge helper path completes successfully and
  creates the expected synthetic merge commit.
