### PR TITLE
sync: propagate pkg-pr-hook to default branches

### DIFF
--- a/.github/pkg-workflows/qli-ci/pkg-pr-hook.yml
+++ b/.github/pkg-workflows/qli-ci/pkg-pr-hook.yml
@@ -1,0 +1,25 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches: [ debian/*, qcom/** ]
+    types: [ opened, synchronize, reopened, closed ]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    name: PR Build
+    if: ${{ github.event.action != 'closed' || github.event.pull_request.merged == true }}
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/pkg-build-reusable-workflow.yml@main
+    with:
+      qcom-build-utils-ref: main
+      # PRE-MERGE: use the PR head branch (github.head_ref)
+      # POST-MERGE: use the base branch name from the PR
+      debian-ref: ${{ (github.event.action == 'closed' && github.event.pull_request.merged) && github.event.pull_request.base.ref || github.head_ref }}
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
+    secrets:
+      DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+      DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}

--- a/.github/workflows/workflows_sync.yml
+++ b/.github/workflows/workflows_sync.yml
@@ -158,6 +158,14 @@ jobs:
               fi
             done
 
+            # Remove legacy PR workflow file on default branch. The canonical
+            # PR hook workflow is pkg-pr-hook.yml.
+            if [[ -f "$DEBIAN_LEGACY_WORKFLOW_FILE" ]]; then
+              echo "    🗑️ Removing legacy workflow: $(basename "$DEBIAN_LEGACY_WORKFLOW_FILE")"
+              rm "$DEBIAN_LEGACY_WORKFLOW_FILE"
+              isDirty=true
+            fi
+
             # Compare and sync workflow files
             for workflow in ../qcom-build-utils/.github/pkg-workflows/qli-ci/*.yml; do
               workflow_name=$(basename "$workflow")


### PR DESCRIPTION
## Summary
- Add `.github/pkg-workflows/qli-ci/pkg-pr-hook.yml` to the default-branch
  template set synced by `Workflows Sync`.
- Update `.github/workflows/workflows_sync.yml` to remove legacy
  `.github/workflows/pr-pre-post-merge.yml` during default-branch sync.

## Why
Many `pkg-*` repos keep `pkg-pr-hook.yml` only on packaging branches, while
`qli-ci` lacks it. This leaves workflow indexing/name behavior stale and makes
PR hook rollout inconsistent.

By adding `pkg-pr-hook.yml` to the `qli-ci` template directory, one
`Workflows Sync` run can push the canonical PR hook caller into each default
branch.

## Behavior after merge
Running `Workflows Sync` will now:
- ensure `.github/workflows/pkg-pr-hook.yml` exists on default branches
  from the `qli-ci` template set
- remove legacy `.github/workflows/pr-pre-post-merge.yml` when present

This is intended to support org-scale cleanup of the old
"PR Pre and Post Merge Build" state.
