### PR TITLE
bootloader,flash: pre-seed VolatileVars.bin for overlay/DTBO loading

### DIFF
--- a/bootloader/build-efi-esp.sh
+++ b/bootloader/build-efi-esp.sh
@@ -18,6 +18,8 @@
 #
 # Resulting ESP contents:
 #   /EFI/BOOT/BOOTAA64.EFI   (standalone GRUB for ARM64 UEFI, removable path)
+#   /VolatileVars.bin        (optional, only with --volatile-vars: pre-seeded
+#                             EBBR UEFI variables, e.g. VendorDtbOverlays)
 #
 # Embedded bootstrap config behavior:
 #   - Search root filesystem by label "system"
@@ -26,6 +28,7 @@
 # Usage:
 #   ./build-efi-esp.sh [--sector-size <size>] [--esp-size-mb <mb>] [--no-install]
 #                     [--root-label <label>] [--out <efi.bin>]
+#                     [--volatile-vars] [--volatile-vars-config <json>]
 #
 # Examples:
 #   ./build-efi-esp.sh
@@ -57,6 +60,10 @@ SECTOR_SIZE=512
 ROOT_LABEL="system"
 ESP_LABEL="system-boot"
 NO_INSTALL=0
+VOLATILE_VARS=0
+VOLATILE_VARS_CONFIG=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 WORKDIR="$(pwd)"
 MNT_DIR="$(mktemp -d -p "${WORKDIR}" efiesp.mnt.XXXXXX)"
@@ -78,12 +85,19 @@ print_usage() {
     cat <<EOF
 Usage:
   $0 [--sector-size <bytes>] [--esp-size-mb <mb>] [--root-label <label>]
-     [--esp-label <label>] [--out <efi.bin>] [--no-install] [-h|--help]
+     [--esp-label <label>] [--out <efi.bin>] [--no-install]
+     [--volatile-vars] [--volatile-vars-config <json>] [-h|--help]
 
 Notes:
   - Produces a FAT32 filesystem image (no GPT inside the file).
   - Installs a standalone ARM64 GRUB as /EFI/BOOT/BOOTAA64.EFI using grub-mkstandalone.
   - At boot, GRUB searches for rootfs by LABEL and loads its /boot/grub/grub.cfg.
+  - --volatile-vars pre-seeds /VolatileVars.bin with default UEFI variables
+    (see gen_volatile_vars.py), e.g. VendorDtbOverlays, so overlay/DTBO
+    loading works from first boot without waiting on firmware-side
+    generation. Off by default — pass it only for platforms that need
+    VolatileVars.bin pre-seeded. --volatile-vars-config forwards a JSON
+    config to gen_volatile_vars.py to add/override entries.
 
 EOF
 }
@@ -105,6 +119,10 @@ while [[ $# -gt 0 ]]; do
             OUT_IMG="${2-}"; shift 2 ;;
         --no-install)
             NO_INSTALL=1; shift ;;
+        --volatile-vars)
+            VOLATILE_VARS=1; shift ;;
+        --volatile-vars-config)
+            VOLATILE_VARS_CONFIG="${2-}"; shift 2 ;;
         -h|--help)
             print_usage; exit 0 ;;
         *)
@@ -113,6 +131,11 @@ while [[ $# -gt 0 ]]; do
             exit 1 ;;
     esac
 done
+
+# --volatile-vars-config implies --volatile-vars
+if [[ -n "${VOLATILE_VARS_CONFIG}" ]]; then
+    VOLATILE_VARS=1
+fi
 
 # ==============================================================================
 # Step 3  Validate inputs
@@ -168,6 +191,10 @@ done
 for c in grub-mkstandalone; do
     need_cmd "${c}" || missing+=("${c}")
 done
+
+if [[ "${VOLATILE_VARS}" -eq 1 ]]; then
+    need_cmd python3 || missing+=("python3")
+fi
 
 if [[ "${#missing[@]}" -gt 0 ]]; then
     echo "[INFO] Missing commands: ${missing[*]}"
@@ -257,6 +284,15 @@ mkdir -p "${MNT_DIR}/EFI/BOOT"
 install -m 0644 "${STANDALONE_EFI}" "${MNT_DIR}/EFI/BOOT/BOOTAA64.EFI"
 rm -f "${STANDALONE_EFI}"
 
+if [[ "${VOLATILE_VARS}" -eq 1 ]]; then
+    echo "[INFO] Generating VolatileVars.bin (pre-seeded UEFI variables)..."
+    GEN_VOLATILE_VARS_ARGS=(--out "${MNT_DIR}/VolatileVars.bin")
+    if [[ -n "${VOLATILE_VARS_CONFIG}" ]]; then
+        GEN_VOLATILE_VARS_ARGS+=(--config "${VOLATILE_VARS_CONFIG}")
+    fi
+    python3 "${SCRIPT_DIR}/gen_volatile_vars.py" "${GEN_VOLATILE_VARS_ARGS[@]}"
+fi
+
 sync
 umount -l "${MNT_DIR}"
 losetup -d "${LOOP_DEV}"
@@ -264,4 +300,7 @@ LOOP_DEV=""
 
 echo "[SUCCESS] EFI System Partition image created: ${OUT_IMG}"
 echo "[INFO] Contains: /EFI/BOOT/BOOTAA64.EFI (standalone GRUB + embedded bootstrap)."
+if [[ "${VOLATILE_VARS}" -eq 1 ]]; then
+    echo "[INFO] Contains: /VolatileVars.bin (pre-seeded UEFI variables)."
+fi
 echo "[INFO] Ensure rootfs filesystem label is '${ROOT_LABEL}' and it provides /boot/grub/grub.cfg."

--- a/bootloader/gen_volatile_vars.py
+++ b/bootloader/gen_volatile_vars.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+"""Generate a VolatileVars.bin for EBBR-style UEFI variable persistence.
+
+Usage:
+    # write VolatileVars.bin with only the built-in default entries
+    python3 gen_volatile_vars.py
+
+    # write to a specific path
+    python3 gen_volatile_vars.py --out /path/to/VolatileVars.bin
+
+    # merge in extra entries from a JSON config (same guid+name as a
+    # default entry overrides it; otherwise the entry is appended)
+    python3 gen_volatile_vars.py --config extra.json --out VolatileVars.bin
+
+Config file format:
+    {
+      "entries": [
+        {
+          "guid": "12345678-1234-1234-1234-123456789abc",
+          "name": "ExampleVar",
+          "attributes": "0x7",
+          "data_hex": "01020304"
+        }
+      ]
+    }
+    Each entry needs exactly one of data_hex / data_b64 / data_utf8.
+
+Format (all little-endian), matches the EFI_VARIABLE_FILE / EFI_VARIABLE_ENTRY
+layout read by the firmware's UpdateVariableFromRTVolatileBin():
+
+EFI_VARIABLE_FILE header (24 bytes):
+    UINT64 Reserved      (0)
+    UINT8  Magic[7]      "UbEfiVa"
+    UINT8  Revision      1
+    UINT32 Length        total file size
+    UINT32 Crc32         zlib crc32 over everything after the header
+
+EFI_VARIABLE_ENTRY, repeated, each 8-byte aligned (32-byte header + name + data):
+    UINT32   DataSize
+    UINT32   Attributes
+    UINT64   Reserved     (0)
+    EFI_GUID VendorGuid   (16 bytes)
+    CHAR16   Name[]       UCS-2, NUL-terminated
+    UINT8    Data[DataSize]
+    <pad to 8-byte alignment>
+"""
+import argparse
+import base64
+import json
+import struct
+import uuid
+import zlib
+
+MAGIC = b"UbEfiVa"
+REVISION = 1
+ALIGNMENT = 8
+
+EFI_VARIABLE_NON_VOLATILE = 0x00000001
+EFI_VARIABLE_BOOTSERVICE_ACCESS = 0x00000002
+EFI_VARIABLE_RUNTIME_ACCESS = 0x00000004
+
+UINT32_MAX = 0xFFFFFFFF
+
+# Always included, even without --config. A --config entry with the same
+# (guid, name) overrides the default below.
+DEFAULT_ENTRIES = [
+    {
+        "guid": "882f8c2b-9646-435f-8de5-f208ff80c1bd",
+        "name": "VendorDtbOverlays",
+        "attributes": (
+            EFI_VARIABLE_NON_VOLATILE
+            | EFI_VARIABLE_BOOTSERVICE_ACCESS
+            | EFI_VARIABLE_RUNTIME_ACCESS
+        ),
+        "data_utf8": "camx",
+    },
+]
+
+
+def _parse_int(value):
+    """Parse an int from either a real int/float or a string like '7', '0x7'.
+
+    Avoids int(x, 0), which rejects legal decimal strings with a leading
+    zero (e.g. "07") by misinterpreting them as octal.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"expected an integer, got bool: {value!r}")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        raise ValueError(f"expected an integer, got float: {value!r}")
+    s = value.strip()
+    if s[:2].lower() == "0x":
+        return int(s, 16)
+    return int(s, 10)
+
+
+def _require_uint32(value, field_name):
+    n = _parse_int(value)
+    if not (0 <= n <= UINT32_MAX):
+        raise ValueError(f"{field_name} must fit in UINT32 (0..{UINT32_MAX}), got {n}")
+    return n
+
+
+def _guid_to_bytes(guid_str):
+    g = uuid.UUID(guid_str)
+    b = g.bytes_le  # EFI_GUID is stored little-endian (matches Data1/Data2/Data3 as LE, Data4 as-is)
+    return b
+
+
+def build_entry(guid_str, name, data, attributes):
+    guid_bytes = _guid_to_bytes(guid_str)
+    name_bytes = name.encode("utf-16-le") + b"\x00\x00"
+    data_size = _require_uint32(len(data), "DataSize")
+    attributes = _require_uint32(attributes, "Attributes")
+    header = struct.pack("<IIQ", data_size, attributes, 0) + guid_bytes
+    entry = header + name_bytes + data
+    pad = (-len(entry)) % ALIGNMENT
+    return entry + b"\x00" * pad
+
+
+def build_volatile_vars(entries):
+    """entries: list of dicts with keys guid, name, data (bytes), attributes"""
+    body = b"".join(
+        build_entry(e["guid"], e["name"], e["data"], e["attributes"])
+        for e in entries
+    )
+    length = 24 + len(body)
+    crc32 = zlib.crc32(body) & 0xFFFFFFFF
+    header = struct.pack("<Q7sBII", 0, MAGIC, REVISION, length, crc32)
+    return header + body
+
+
+def _decode_data(entry):
+    """Accept data as one of: data_hex, data_b64, data_utf8. Exactly one must be set."""
+    present = [k for k in ("data_hex", "data_b64", "data_utf8") if k in entry]
+    if len(present) > 1:
+        raise ValueError(
+            f"entry {entry.get('name')!r} has multiple data fields set {present}; "
+            "exactly one of data_hex/data_b64/data_utf8 is allowed"
+        )
+    if "data_hex" in entry:
+        return bytes.fromhex(entry["data_hex"])
+    if "data_b64" in entry:
+        return base64.b64decode(entry["data_b64"])
+    if "data_utf8" in entry:
+        return entry["data_utf8"].encode("utf-8")
+    raise ValueError(f"entry {entry.get('name')!r} missing data_hex/data_b64/data_utf8")
+
+
+def _parse_raw_entries(raw_entries, source):
+    entries = []
+    for i, e in enumerate(raw_entries):
+        label = e.get("name", f"<unnamed entry {i}>")
+        try:
+            entries.append(
+                {
+                    "guid": e["guid"],
+                    "name": e["name"],
+                    "data": _decode_data(e),
+                    "attributes": _parse_int(e["attributes"]),
+                }
+            )
+        except KeyError as ex:
+            raise ValueError(f"{source} entry {i} ({label!r}) missing required field: {ex}") from ex
+        except ValueError as ex:
+            raise ValueError(f"{source} entry {i} ({label!r}): {ex}") from ex
+    return entries
+
+
+def load_entries_from_config(path):
+    with open(path) as f:
+        cfg = json.load(f)
+    if "entries" not in cfg:
+        raise ValueError(f"{path}: missing top-level 'entries' array")
+    return _parse_raw_entries(cfg["entries"], path)
+
+
+def merge_entries(default_entries, override_entries):
+    """override_entries with the same (guid, name) as a default replace it;
+    otherwise they're appended. Order of defaults is preserved."""
+    overrides_by_key = {(e["guid"].lower(), e["name"]): e for e in override_entries}
+    merged = []
+    used_keys = set()
+    for e in default_entries:
+        key = (e["guid"].lower(), e["name"])
+        merged.append(overrides_by_key.get(key, e))
+        used_keys.add(key)
+    for e in override_entries:
+        key = (e["guid"].lower(), e["name"])
+        if key not in used_keys:
+            merged.append(e)
+    return merged
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        help="JSON file describing additional/override variable entries "
+        "(merged with the built-in defaults; an entry with the same "
+        "guid+name as a default replaces it)",
+    )
+    parser.add_argument("--out", default="VolatileVars.bin", help="output file path")
+    args = parser.parse_args()
+
+    default_entries = _parse_raw_entries(DEFAULT_ENTRIES, "<default>")
+    config_entries = load_entries_from_config(args.config) if args.config else []
+    entries = merge_entries(default_entries, config_entries)
+
+    data = build_volatile_vars(entries)
+    with open(args.out, "wb") as f:
+        f.write(data)
+    print(f"wrote {len(data)} bytes to {args.out} ({len(entries)} entries)")

--- a/bootloader/patch-volatile-vars.sh
+++ b/bootloader/patch-volatile-vars.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# ==============================================================================
+# Script: patch-volatile-vars.sh
+# ------------------------------------------------------------------------------
+# Description:
+#   Writes VolatileVars.bin (see gen_volatile_vars.py) into the root of an
+#   EXISTING FAT32 ESP image, in place, using mtools (mcopy). Unlike
+#   build-efi-esp.sh, this does not format the image or install GRUB, and it
+#   does not require loop devices/mounting or root — mtools operates directly
+#   on the image file. Intended for flows where a single efi.bin is built
+#   once and shared across boards (see flash/gen-flash-dirs.sh), so only the
+#   board(s) that need VolatileVars.bin get it patched into their own copy.
+#
+# Usage:
+#   ./patch-volatile-vars.sh --efi <efi.bin> [--config <json>]
+#
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+EFI_IMG=""
+VOLATILE_VARS_CONFIG=""
+
+print_usage() {
+    cat <<EOF
+Usage:
+  $0 --efi <efi.bin> [--config <json>] [-h|--help]
+
+Notes:
+  - <efi.bin> must already be a formatted FAT32 filesystem image; it is
+    modified in place via mtools (no mount/loop device/root required).
+  - --config forwards a JSON config to gen_volatile_vars.py to add/override
+    entries on top of its built-in defaults (see gen_volatile_vars.py).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --efi)
+            EFI_IMG="${2-}"; shift 2 ;;
+        --config)
+            VOLATILE_VARS_CONFIG="${2-}"; shift 2 ;;
+        -h|--help)
+            print_usage; exit 0 ;;
+        *)
+            echo "[ERROR] Unknown argument: $1"
+            print_usage
+            exit 1 ;;
+    esac
+done
+
+if [[ -z "${EFI_IMG}" ]]; then
+    echo "[ERROR] --efi is required"
+    print_usage
+    exit 1
+fi
+if [[ ! -f "${EFI_IMG}" ]]; then
+    echo "[ERROR] EFI image not found: ${EFI_IMG}"
+    exit 1
+fi
+
+command -v python3 >/dev/null 2>&1 || { echo "[ERROR] python3 is required"; exit 1; }
+
+if ! command -v mcopy >/dev/null 2>&1; then
+    echo "[INFO] mcopy (mtools) not found — attempting to install..."
+    if [[ "${EUID}" -eq 0 ]]; then
+        APT_GET=(apt-get)
+    elif command -v sudo >/dev/null 2>&1; then
+        APT_GET=(sudo apt-get)
+    else
+        echo "[ERROR] mcopy (mtools) is required and not installable without root/sudo"
+        exit 1
+    fi
+    DEBIAN_FRONTEND=noninteractive "${APT_GET[@]}" update -y
+    DEBIAN_FRONTEND=noninteractive "${APT_GET[@]}" install -y mtools
+    command -v mcopy >/dev/null 2>&1 || { echo "[ERROR] mcopy still not found after install attempt"; exit 1; }
+fi
+
+TMP_VV="$(mktemp -p "$(dirname "${EFI_IMG}")" patchvv.XXXXXX.bin)"
+cleanup() { rm -f "${TMP_VV}"; }
+trap cleanup EXIT
+
+GEN_VOLATILE_VARS_ARGS=(--out "${TMP_VV}")
+if [[ -n "${VOLATILE_VARS_CONFIG}" ]]; then
+    GEN_VOLATILE_VARS_ARGS+=(--config "${VOLATILE_VARS_CONFIG}")
+fi
+python3 "${SCRIPT_DIR}/gen_volatile_vars.py" "${GEN_VOLATILE_VARS_ARGS[@]}"
+
+echo "[INFO] Writing VolatileVars.bin into ${EFI_IMG}..."
+mcopy -o -i "${EFI_IMG}" "${TMP_VV}" "::VolatileVars.bin"
+
+echo "[SUCCESS] Patched VolatileVars.bin into: ${EFI_IMG}"

--- a/flash/gen-flash-dirs.sh
+++ b/flash/gen-flash-dirs.sh
@@ -10,6 +10,10 @@
 #
 # Per-storage image placement:
 #   nvme/ufs/emmc: efi.bin (4096-byte sectors for ufs/nvme, 512 for emmc)
+#                  VolatileVars.bin patched into that target's own copy of
+#                  efi.bin when "volatile_vars": true in targets.json (see
+#                  bootloader/patch-volatile-vars.sh) — other targets sharing
+#                  the same source efi.bin are unaffected
 #                  dtb.bin (only if the target has no spinor storage)
 #                  rootfs.img referenced as ../../rootfs.img in rawprogram XMLs
 #   spinor:        dtb.bin only (firmware-only; no efi or rootfs)
@@ -33,6 +37,8 @@
 # ==============================================================================
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ------------------------------------------------------------------------------
 # Sector size per storage type (ufs/nvme: 4096, emmc: 512)
@@ -136,6 +142,7 @@ for i in $(seq 0 $((BOARD_COUNT - 1))); do
     BOARD_NAME=$(echo "$BOARDS_JSON"     | jq -r ".[$i].name")
     PTOOL_PLATFORM=$(echo "$BOARDS_JSON" | jq -r ".[$i].ptool_platform")
     CDT_FILENAME=$(echo "$BOARDS_JSON"   | jq -r ".[$i].cdt_filename // empty")
+    VOLATILE_VARS=$(echo "$BOARDS_JSON"  | jq -r ".[$i].volatile_vars // false")
 
     echo ""
     echo "========================================================"
@@ -304,6 +311,11 @@ for i in $(seq 0 $((BOARD_COUNT - 1))); do
                 else
                     echo "[ERROR] efi.bin not found for ${storage} (sector size ${SECTOR_SIZE})"
                     exit 1
+                fi
+
+                if [[ "$VOLATILE_VARS" == "true" ]]; then
+                    "${SCRIPT_DIR}/../bootloader/patch-volatile-vars.sh" \
+                        --efi "${STORAGE_DIR}/efi.bin"
                 fi
 
                 if [[ "$HAS_SPINOR" == "false" ]]; then

--- a/flash/parse-boards-config.py
+++ b/flash/parse-boards-config.py
@@ -13,6 +13,7 @@
 #       "cdt_url":          "https://...",         (optional, default "")
 #       "cdt_filename":     "cdt_foo.bin",         (optional, default "")
 #       "contents_xml_in":  "platform/foo/..."     (optional, default "")
+#       "volatile_vars":    true                   (optional, default false)
 #     },
 #     ...
 #   ]
@@ -58,6 +59,7 @@ def main() -> int:
         t.setdefault("cdt_url", "")
         t.setdefault("cdt_filename", "")
         t.setdefault("contents_xml_in", "")
+        t.setdefault("volatile_vars", False)
 
     print(json.dumps(targets, indent=2))
     return 0


### PR DESCRIPTION
**Summary**
  Add tooling to pre-seed VolatileVars.bin with the VendorDtbOverlays UEFI variable at build time, and wire it into the flat-meta flash pipeline on a per-board basis.

  **Why**
  Tech team requires overlay-based DTBO loading to work out of the box, which depends on the VendorDtbOverlays UEFI variable being present in VolatileVars.bin. Today this file is only ever generated by the firmware itself during the UEFI boot stage — there's no way to seed it ahead of time.

  This means the variable doesn't exist on first boot (or after any reset that wipes the ESP), so overlay/DTBO loading can't be relied upon without an extra runtime step.

  In the flat-meta flash pipeline, a single CI job can build one shared efi.bin and reuse it across several boards (see targets.json). Only some of those boards need VolatileVars.bin pre-seeded, so the injection needs to be per-board rather than per-platform/suite, and it needs to work against an *existing* efi.bin (not just a freshly-built one).

  **What it does**
  - `bootloader/gen_volatile_vars.py` — builds an EBBR-style VolatileVars.bin (EFI_VARIABLE_FILE + EFI_VARIABLE_ENTRY layout consumed by `UpdateVariableFromRTVolatileBin()`). Ships a built-in default entry for `VendorDtbOverlays` (`camx`). Accepts an optional `--config extra.json` to add/override entries (matched by guid+name) without touching the script.
  - `bootloader/build-efi-esp.sh` — new `--volatile-vars` / `--volatile-vars-config` flags to bake VolatileVars.bin into a freshly built ESP image.
  - `bootloader/patch-volatile-vars.sh` — writes VolatileVars.bin into an *existing* FAT32 image in place via mtools (`mcopy`), no loop device/mount/root required. Used when one efi.bin is built once and reused across multiple boards.
  - `flash/parse-boards-config.py` / `flash/gen-flash-dirs.sh` — new `"volatile_vars"` field (bool, default `false`) in `targets.json`. When `true` for a board, `gen-flash-dirs.sh` patches that board's own efi.bin copy after staging it, leaving other boards sharing the same source efi.bin unaffected.

  **Usage**
  python3 gen_volatile_vars.py --out VolatileVars.bin
  ./build-efi-esp.sh --volatile-vars --out efi.bin
  ./patch-volatile-vars.sh --efi efi.bin
