### PR TITLE
build_package: drop --no-symlink from uscan invocation

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -242,7 +242,7 @@ runs:
           # the upstream git tag — the normal gbp path handles those correctly.
           if [[ -f "./debian/watch" ]] && grep -q "qartifactory" "./debian/watch"; then
             echo "ℹ️ debian/watch (Artifactory) found — fetching orig tarball via uscan"
-            uscan --no-symlink --destdir "$WORK_DIR" --download-current-version
+            uscan --destdir "$WORK_DIR" --download-current-version
             GBP_ORIG_FLAGS=(--git-no-create-orig)
           else
             GBP_ORIG_FLAGS=()


### PR DESCRIPTION
## Summary

Follow-up to #201. The `--no-symlink` flag prevented uscan from creating
the `.orig.tar.gz` symlink, causing `dpkg-source -b` to fail with
`no upstream tarball found`.

uscan's default `--symlink` behaviour downloads the upstream tarball and
creates a `<pkg>_<ver>.orig.tar.gz` symlink in `WORK_DIR`. Since both
land in the same directory that `dpkg-source` looks in, the orig tarball
is found correctly without needing `filenamemangle` in `debian/watch`.
