### PR TITLE
release: increment trailing numeric part of debian revision on UNRELEASED bump

### DIFF
--- a/.github/pkg-workflows/debian/pkg-pr-hook.yml
+++ b/.github/pkg-workflows/debian/pkg-pr-hook.yml
@@ -15,14 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark Debusine CI pending
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: 'pending',
-              context: 'Debusine CI',
-              description: 'Running unified Debian/Ubuntu PR build...'
-            });
+        env:
+          GH_API_TOKEN: ${{ github.token }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          curl --fail-with-body -sS \
+            -X POST \
+            -H "Authorization: Bearer ${GH_API_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${PR_HEAD_SHA}" \
+            -d '{"state":"pending","context":"Debusine CI","description":"Running unified Debian/Ubuntu PR build..."}'

--- a/.github/pkg-workflows/debian/pkg-pr-hook.yml
+++ b/.github/pkg-workflows/debian/pkg-pr-hook.yml
@@ -1,25 +1,28 @@
-name: PR Build
+name: PR Build Hook
 
 on:
   pull_request:
-    branches: [ debian/*, qcom/** ]
-    types: [ opened, synchronize, reopened, closed ]
+    branches: [ debian/*, qcom/**, qli/**, qli-staging/** ]
+    types: [ opened, synchronize, reopened ]
 
 permissions:
   contents: read
-  packages: read
+  statuses: write
 
 jobs:
-  build:
-    name: PR Build
-    if: ${{ github.event.action != 'closed' || github.event.pull_request.merged == true }}
-    uses: qualcomm-linux/qcom-build-utils/.github/workflows/pkg-build-reusable-workflow.yml@main
-    with:
-      qcom-build-utils-ref: main
-      # PRE-MERGE: use the PR head branch (github.head_ref)
-      # POST-MERGE: use the base branch name from the PR
-      debian-ref: ${{ (github.event.action == 'closed' && github.event.pull_request.merged) && github.event.pull_request.base.ref || github.head_ref }}
-      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
-    secrets:
-      DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
-      DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+  set-pending-status:
+    name: Set Debusine CI Pending
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark Debusine CI pending
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              context: 'Debusine CI',
+              description: 'Running unified Debian/Ubuntu PR build...'
+            });

--- a/.github/pkg-workflows/debian/pkg-pr-hook.yml
+++ b/.github/pkg-workflows/debian/pkg-pr-hook.yml
@@ -11,10 +11,10 @@ permissions:
 
 jobs:
   set-pending-status:
-    name: Set Debusine CI Pending
+    name: Set PR Build Pending
     runs-on: ubuntu-latest
     steps:
-      - name: Mark Debusine CI pending
+      - name: Mark PR Build pending
         env:
           GH_API_TOKEN: ${{ github.token }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -27,4 +27,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${PR_HEAD_SHA}" \
-            -d '{"state":"pending","context":"Debusine CI","description":"Running unified Debian/Ubuntu PR build..."}'
+            -d '{"state":"pending","context":"PR Build","description":"Running unified Debian/Ubuntu PR build..."}'

--- a/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
+++ b/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
@@ -2,7 +2,9 @@ name: PR Build Check
 
 on:
   workflow_run:
-    workflows: [ "PR Build Hook" ]
+    # Include legacy names observed in existing repos to keep workflow_run wired
+    # during migration from older hook definitions.
+    workflows: [ "PR Build Hook", "PR Pre and Post Merge Build", "PR Build" ]
     types: [ completed ]
 
 permissions:

--- a/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
+++ b/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
@@ -2,9 +2,7 @@ name: PR Build Check
 
 on:
   workflow_run:
-    # Include legacy names observed in existing repos to keep workflow_run wired
-    # during migration from older hook definitions.
-    workflows: [ "PR Build Hook", "PR Pre and Post Merge Build", "PR Build" ]
+    workflows: [ "PR Build Hook" ]
     types: [ completed ]
 
 permissions:

--- a/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
+++ b/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
@@ -1,0 +1,59 @@
+name: PR Build Check
+
+on:
+  workflow_run:
+    workflows: [ "PR Build Hook" ]
+    types: [ completed ]
+
+permissions:
+  contents: read
+  packages: read
+  statuses: write
+
+jobs:
+  build:
+    name: PR Build
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0] != null }}
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/pkg-build-reusable-workflow.yml@main
+    with:
+      qcom-build-utils-ref: main
+      debian-ref: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+      source-ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/merge
+      debusine-parent-workspace: ${{ vars.DEBUSINE_PARENT_WORKSPACE }}
+    secrets:
+      DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
+      DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
+
+  set-final-status:
+    name: Set Debusine CI Result
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ always() && github.event.workflow_run.pull_requests[0] != null }}
+    steps:
+      - name: Set success status
+        if: needs.build.result == 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              state: 'success',
+              context: 'Debusine CI',
+              description: 'Unified Debian/Ubuntu PR build passed'
+            });
+
+      - name: Set failure status
+        if: needs.build.result != 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              state: 'failure',
+              context: 'Debusine CI',
+              description: 'Unified Debian/Ubuntu PR build failed'
+            });

--- a/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
+++ b/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
@@ -25,7 +25,7 @@ jobs:
       DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
 
   set-final-status:
-    name: Set Debusine CI Result
+    name: Set PR Build Result
     runs-on: ubuntu-latest
     needs: build
     if: ${{ always() && github.event.workflow_run.pull_requests[0] != null }}
@@ -52,4 +52,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${WORKFLOW_HEAD_SHA}" \
-            -d "{\"state\":\"${status_state}\",\"context\":\"Debusine CI\",\"description\":\"${status_description}\"}"
+            -d "{\"state\":\"${status_state}\",\"context\":\"PR Build\",\"description\":\"${status_description}\"}"

--- a/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
+++ b/.github/pkg-workflows/qli-ci/pkg-pr-check.yml
@@ -30,30 +30,26 @@ jobs:
     needs: build
     if: ${{ always() && github.event.workflow_run.pull_requests[0] != null }}
     steps:
-      - name: Set success status
-        if: needs.build.result == 'success'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.workflow_run.head_sha,
-              state: 'success',
-              context: 'Debusine CI',
-              description: 'Unified Debian/Ubuntu PR build passed'
-            });
+      - name: Set final status
+        env:
+          GH_API_TOKEN: ${{ github.token }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
 
-      - name: Set failure status
-        if: needs.build.result != 'success'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.workflow_run.head_sha,
-              state: 'failure',
-              context: 'Debusine CI',
-              description: 'Unified Debian/Ubuntu PR build failed'
-            });
+          if [[ "$BUILD_RESULT" == "success" ]]; then
+            status_state="success"
+            status_description="Unified Debian/Ubuntu PR build passed"
+          else
+            status_state="failure"
+            status_description="Unified Debian/Ubuntu PR build failed"
+          fi
+
+          curl --fail-with-body -sS \
+            -X POST \
+            -H "Authorization: Bearer ${GH_API_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${WORKFLOW_HEAD_SHA}" \
+            -d "{\"state\":\"${status_state}\",\"context\":\"Debusine CI\",\"description\":\"${status_description}\"}"

--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -443,7 +443,7 @@ jobs:
       srcpkg_version: ${{ steps.select.outputs.srcpkg_version }}
     runs-on: ubuntu-24.04-arm
     container:
-      image: ${{ (needs.resolve.outputs.family == 'debian' && needs.resolve.outputs.force_docker_build != 'true') && format('ghcr.io/qualcomm-linux/debusine-pkg-builder:{0}', needs.resolve.outputs.suite) || format('ghcr.io/qualcomm-linux/pkg-builder:{0}', needs.resolve.outputs.docker_suite) }}
+      image: ${{ format('ghcr.io/qualcomm-linux/pkg-builder:{0}', needs.resolve.outputs.docker_suite) }}
       options: --user 0:0
       credentials:
         username: ${{ github.actor }}

--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -18,6 +18,11 @@ on:
         type: string
         required: true
 
+      source-ref:
+        description: Optional ref to check out for build content; defaults to debian-ref
+        type: string
+        default: ""
+
       run-lintian:
         description: Run lintian or not during the Docker pkg-builder build path
         type: boolean
@@ -73,8 +78,14 @@ on:
         description: The resolved distro family (`debian` or `ubuntu`)
         value: ${{ jobs.resolve.outputs.family }}
       suite:
-        description: The resolved suite/codename actually used by the workflow
+        description: The resolved suite/codename for Debusine path and exported metadata
         value: ${{ jobs.resolve.outputs.suite }}
+      debusine_target_workspace:
+        description: Debusine target workspace derived from branch prefix
+        value: ${{ jobs.resolve.outputs.debusine_target_workspace }}
+      package_version_identifier:
+        description: Package version identifier for Debusine release bump logic
+        value: ${{ jobs.resolve.outputs.package_version_identifier }}
       workspace:
         description: Debusine workspace ID for Debusine builds; empty for Docker builds
         value: ${{ jobs.test.outputs.workspace }}
@@ -103,8 +114,13 @@ jobs:
     name: Resolve branch target
     runs-on: ubuntu-latest
     outputs:
+      debusine_target_workspace: ${{ steps.resolve.outputs.debusine_target_workspace }}
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
+      docker_suite: ${{ steps.resolve.outputs.docker_suite }}
+      extra_build_dep_workspaces: ${{ steps.resolve.outputs.extra_build_dep_workspaces }}
       family: ${{ steps.resolve.outputs.family }}
       force_docker_build: ${{ steps.resolve.outputs.force_docker_build }}
+      package_version_identifier: ${{ steps.resolve.outputs.package_version_identifier }}
       suite: ${{ steps.resolve.outputs.suite }}
     steps:
       - name: Checkout qcom-build-utils scripts
@@ -122,6 +138,7 @@ jobs:
           BASE_REF_INPUT: ${{ github.base_ref }}
           DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
           FORCE_DOCKER_BUILD: ${{ inputs.force-docker-build }}
+          SOURCE_REF_INPUT: ${{ inputs.source-ref }}
         run: |
           set -euo pipefail
 
@@ -143,7 +160,34 @@ jobs:
             done <<< "$resolved_kv"
           }
 
+          resolve_debusine_contract() {
+            local branch_ref="$1"
+
+            case "$branch_ref" in
+              qli-staging/*)
+                debusine_target_workspace="qli-staging"
+                package_version_identifier="qli+staging"
+                extra_build_dep_workspaces="qli qli-staging"
+                ;;
+              qli/*|qcom/*)
+                debusine_target_workspace="qli"
+                package_version_identifier="qli"
+                extra_build_dep_workspaces="qli"
+                ;;
+              *)
+                echo "::warning::Unrecognized Debian branch prefix in '${branch_ref}'; defaulting Debusine contract to workspace='qli', identifier='qli'."
+                debusine_target_workspace="qli"
+                package_version_identifier="qli"
+                extra_build_dep_workspaces="qli"
+                ;;
+            esac
+          }
+
           source_ref=""
+          checkout_ref="$DEBIAN_REF_INPUT"
+          if [[ -n "$SOURCE_REF_INPUT" ]]; then
+            checkout_ref="$SOURCE_REF_INPUT"
+          fi
           if resolved_kv="$("$RESOLVER_SCRIPT" "$DEBIAN_REF_INPUT")"; then
             parse_resolved_values "$resolved_kv"
             source_ref="$normalized_ref"
@@ -163,25 +207,48 @@ jobs:
             fi
           fi
 
-          # Preserve Debian aliases used in branch names.
-          if [[ "$family" == "debian" ]] && [[ "$suite" == "latest" || "$suite" == "unstable" ]]; then
-            suite=sid
+          docker_suite="$suite"
+          debusine_target_workspace=""
+          package_version_identifier=""
+          extra_build_dep_workspaces=""
+
+          if [[ "$family" == "debian" ]]; then
+            # Align Debian mapping with debusine-action.
+            case "$suite" in
+              latest)
+                suite=forky
+                docker_suite=sid
+                ;;
+              unstable)
+                suite=sid
+                docker_suite=sid
+                ;;
+              *)
+                docker_suite="$suite"
+                ;;
+            esac
+            resolve_debusine_contract "$source_ref"
           fi
 
           force_docker_build=false
           if [[ "$family" == "debian" ]] && [[ -z "$DEBUSINE_TOKEN" || "$FORCE_DOCKER_BUILD" == "true" ]]; then
             force_docker_build=true
             if [[ -z "$DEBUSINE_TOKEN" ]]; then
-              echo "::warning::DEBUSINE_TOKEN is not set or not accessible (fork PR secrets are unavailable to workflows triggered by external contributors) — falling back to local pkg-builder for suite '$suite'"
+              echo "::warning::DEBUSINE_TOKEN is not set or not accessible (fork PR secrets are unavailable to workflows triggered by external contributors) — falling back to local pkg-builder for suite '$docker_suite'"
             else
-              echo "::notice::force-docker-build is set — using local pkg-builder for suite '$suite'"
+              echo "::notice::force-docker-build is set — using local pkg-builder for suite '$docker_suite'"
             fi
           fi
 
-          echo "::notice title=Resolved build target::debian-ref='${DEBIAN_REF_INPUT}', source-ref='${source_ref}', family='${family}', suite='${suite}', force-docker-build='${force_docker_build}'"
+          echo "::notice title=Resolved build target::debian-ref='${DEBIAN_REF_INPUT}', checkout-ref='${checkout_ref}', source-ref='${source_ref}', family='${family}', suite='${suite}', docker-suite='${docker_suite}', debusine-target-workspace='${debusine_target_workspace}', package-version-identifier='${package_version_identifier}', force-docker-build='${force_docker_build}'"
 
+          echo "checkout_ref=$checkout_ref" >> "$GITHUB_OUTPUT"
+          echo "debusine_target_workspace=$debusine_target_workspace" >> "$GITHUB_OUTPUT"
+          echo "docker_suite=$docker_suite" >> "$GITHUB_OUTPUT"
+          echo "extra_build_dep_workspaces=$extra_build_dep_workspaces" >> "$GITHUB_OUTPUT"
           echo "family=$family" >> "$GITHUB_OUTPUT"
           echo "force_docker_build=$force_docker_build" >> "$GITHUB_OUTPUT"
+          echo "package_version_identifier=$package_version_identifier" >> "$GITHUB_OUTPUT"
           echo "suite=$suite" >> "$GITHUB_OUTPUT"
 
   docker-build:
@@ -196,7 +263,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/qualcomm-linux/pkg-builder:${{ needs.resolve.outputs.suite }}
+      image: ghcr.io/qualcomm-linux/pkg-builder:${{ needs.resolve.outputs.docker_suite }}
       options: --privileged
       credentials:
         username: ${{ github.actor }}
@@ -216,7 +283,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.debian-ref }}
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
           path: package-repo
           fetch-depth: 0
           fetch-tags: true
@@ -231,7 +298,7 @@ jobs:
       - name: Build Debian Packages
         uses: ./qcom-build-utils/.github/actions/build_package
         with:
-          suite: ${{ needs.resolve.outputs.suite }}
+          suite: ${{ needs.resolve.outputs.docker_suite }}
           pkg-dir: package-repo
           build-dir: build-area
           run-lintian: ${{ inputs.run-lintian }}
@@ -241,7 +308,7 @@ jobs:
         if: ${{ inputs.run-abi-checker }}
         uses: ./qcom-build-utils/.github/actions/abi_checker
         with:
-          apt-repository: "deb [arch=arm64 trusted=yes] https://qartifactory-edge.qualcomm.com/artifactory/qsc-deb-releases ${{ needs.resolve.outputs.suite }} main"
+          apt-repository: "deb [arch=arm64 trusted=yes] https://qartifactory-edge.qualcomm.com/artifactory/qsc-deb-releases ${{ needs.resolve.outputs.docker_suite }} main"
 
       - name: Upload Docker build artifacts
         run: |
@@ -289,7 +356,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.debian-ref }}
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
           path: srcpkg
           fetch-depth: 0
           fetch-tags: true
@@ -298,6 +365,7 @@ jobs:
         if: ${{ inputs.release }}
         env:
           SUITE_INPUT: ${{ needs.resolve.outputs.suite }}
+          DEBUSINE_TARGET_WORKSPACE: ${{ needs.resolve.outputs.debusine_target_workspace }}
         run: |
           set -ex
           echo "::group::Prepare release"
@@ -321,8 +389,10 @@ jobs:
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           DEBUSINE_HOST: ${{ vars.DEBUSINE_HOST }}
           DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
+          DEBUSINE_USER: ${{ secrets.DEBUSINE_USER }}
           DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_TOKEN }}
           DEBUSINE_PARENT_WORKSPACE: ${{ inputs.debusine-parent-workspace }}
+          EXTRA_BUILD_DEP_WORKSPACES: ${{ needs.resolve.outputs.extra_build_dep_workspaces }}
           SUITE: ${{ needs.resolve.outputs.suite }}
         run: |
           set -euxo pipefail
@@ -373,7 +443,7 @@ jobs:
       srcpkg_version: ${{ steps.select.outputs.srcpkg_version }}
     runs-on: ubuntu-24.04-arm
     container:
-      image: ${{ format('ghcr.io/qualcomm-linux/pkg-builder:{0}', needs.resolve.outputs.suite) }}
+      image: ${{ (needs.resolve.outputs.family == 'debian' && needs.resolve.outputs.force_docker_build != 'true') && format('ghcr.io/qualcomm-linux/debusine-pkg-builder:{0}', needs.resolve.outputs.suite) || format('ghcr.io/qualcomm-linux/pkg-builder:{0}', needs.resolve.outputs.docker_suite) }}
       options: --user 0:0
       credentials:
         username: ${{ github.actor }}
@@ -408,7 +478,7 @@ jobs:
         if: ${{ needs.resolve.outputs.family == 'debian' && needs.resolve.outputs.force_docker_build != 'true' }}
         uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.debian-ref }}
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
           path: srcpkg
           fetch-depth: 1
 
@@ -431,7 +501,7 @@ jobs:
           install -m 0600 debusine-ci-auth.conf /etc/apt/auth.conf.d/debusine-ci-auth.conf
 
           qartifactory_suite="$SUITE"
-          if [ "$qartifactory_suite" = "unstable" ]; then
+          if [ "$qartifactory_suite" = "unstable" ] || [ "$qartifactory_suite" = "forky" ]; then
             qartifactory_suite=sid
           fi
 
@@ -495,7 +565,7 @@ jobs:
           set -euxo pipefail
 
           # Add qsc-deb-releases so Qualcomm package dependencies are resolvable
-          suite="${{ needs.resolve.outputs.suite }}"
+          suite="${{ needs.resolve.outputs.docker_suite }}"
           install -d /etc/apt/keyrings /etc/apt/sources.list.d
           cat > /etc/apt/keyrings/qsc-deb-releases.asc <<'KEYEOF'
           -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -496,13 +496,19 @@ jobs:
           upstream="${version%-*}"
           rev="${version##*-}"
 
-          if ! [[ "$rev" =~ ^[0-9]+$ ]]; then
-            echo "Error: debian revision '$rev' is not numeric" >&2
+          if [[ "$rev" =~ ^(.*[^0-9])([0-9]+)$ ]]; then
+            rev_prefix="${BASH_REMATCH[1]}"
+            rev_num="${BASH_REMATCH[2]}"
+          elif [[ "$rev" =~ ^([0-9]+)$ ]]; then
+            rev_prefix=""
+            rev_num="${BASH_REMATCH[1]}"
+          else
+            echo "Error: debian revision '$rev' has no trailing numeric part" >&2
             exit 1
           fi
 
-          rev=$((rev + 1))
-          newversion="${upstream}-${rev}~"
+          rev_num=$((10#${rev_num} + 1))
+          newversion="${upstream}-${rev_prefix}${rev_num}~"
           echo "Bumped version -> ${newversion}"
           dch --newversion="${newversion}" --distribution=UNRELEASED --controlmaint "WIP — update changelog before next release"
 

--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -98,8 +98,11 @@ jobs:
             esac
           done <<< "$resolved_kv"
 
-          if [[ "$family" == "debian" ]] && [[ "$suite" == "latest" || "$suite" == "unstable" ]]; then
-            suite=sid
+          if [[ "$family" == "debian" ]]; then
+            case "$suite" in
+              latest) suite=forky ;;
+              unstable) suite=sid ;;
+            esac
           fi
 
           echo "::notice title=Resolved release target::debian-branch='${DEBIAN_REF_INPUT}', family='${family}', suite='${suite}'"
@@ -310,9 +313,19 @@ jobs:
       - name: Require Debusine release token
         env:
           DEBUSINE_RELEASE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}
+          DEBUSINE_TARGET_WORKSPACE: ${{ needs.build-and-test.outputs.debusine_target_workspace }}
+          PACKAGE_VERSION_IDENTIFIER: ${{ needs.build-and-test.outputs.package_version_identifier }}
         run: |
           if [ -z "$DEBUSINE_RELEASE_TOKEN" ]; then
             echo "DEBUSINE_RELEASE_TOKEN is required when publishing Debian releases" >&2
+            exit 1
+          fi
+          if [ -z "$DEBUSINE_TARGET_WORKSPACE" ]; then
+            echo "debusine_target_workspace output is required for Debian releases" >&2
+            exit 1
+          fi
+          if [ -z "$PACKAGE_VERSION_IDENTIFIER" ]; then
+            echo "package_version_identifier output is required for Debian releases" >&2
             exit 1
           fi
 
@@ -322,7 +335,7 @@ jobs:
           DEBUSINE_SCOPE: ${{ vars.DEBUSINE_SCOPE }}
           DEBUSINE_TOKEN: ${{ secrets.DEBUSINE_RELEASE_TOKEN }}
           DEBUSINE_CI_WORKSPACE: ${{ needs.build-and-test.outputs.workspace }}
-          DEBUSINE_TARGET_WORKSPACE: prod
+          DEBUSINE_TARGET_WORKSPACE: ${{ needs.build-and-test.outputs.debusine_target_workspace }}
           SRCPKG_NAME: ${{ needs.build-and-test.outputs.srcpkg_name }}
           SRCPKG_VERSION: ${{ needs.build-and-test.outputs.srcpkg_version }}
           SUITE: ${{ needs.build-and-test.outputs.suite }}
@@ -332,6 +345,8 @@ jobs:
           debusine-action/lib/release
 
       - name: Push release git state
+        env:
+          PACKAGE_VERSION_IDENTIFIER: ${{ needs.build-and-test.outputs.package_version_identifier }}
         run: |
           set -euxo pipefail
 

--- a/.github/workflows/workflows_sync.yml
+++ b/.github/workflows/workflows_sync.yml
@@ -64,6 +64,11 @@ jobs:
           DEBIAN_LATEST_WORKFLOW_FILE="$(pwd)/qcom-build-utils/.github/pkg-workflows/debian/pkg-pr-hook.yml"
           DEBIAN_TARGET_WORKFLOW_FILE=".github/workflows/pkg-pr-hook.yml"
           DEBIAN_LEGACY_WORKFLOW_FILE=".github/workflows/pr-pre-post-merge.yml"
+          DEFAULT_BRANCH_WORKFLOW_TEMPLATES=("pkg-build.yml" \
+                                             "pkg-pr-check.yml" \
+                                             "pkg-promote-prebuilt.yml" \
+                                             "pkg-promote.yml" \
+                                             "pkg-release.yml")
           LEGACY_UPSTREAM_HELPER_DIR=".github/TO_PASTE_IN_UPSTREAM_REPO"
           echo "📄 Using pkg-pr-hook.yml from pkg-workflows/debian/"
 
@@ -158,9 +163,29 @@ jobs:
               fi
             done
 
+            # Remove standalone debusine-* callers now replaced by pkg-* flows.
+            if [[ -d ".github/workflows" ]]; then
+              debusine_workflows=$(find .github/workflows -maxdepth 1 -type f \
+                \( -name 'debusine-*.yml' -o -name 'debusine-*.yaml' \) \
+                | sort || true)
+              if [[ -n "$debusine_workflows" ]]; then
+                echo "    🗑️ Removing legacy debusine-* workflows"
+                while IFS= read -r workflow_file; do
+                  [[ -z "$workflow_file" ]] && continue
+                  echo "      - $workflow_file"
+                  rm -f "$workflow_file"
+                done <<< "$debusine_workflows"
+                isDirty=true
+              fi
+            fi
+
             # Compare and sync workflow files
-            for workflow in ../qcom-build-utils/.github/pkg-workflows/qli-ci/*.yml; do
-              workflow_name=$(basename "$workflow")
+            for workflow_name in "${DEFAULT_BRANCH_WORKFLOW_TEMPLATES[@]}"; do
+              workflow="../qcom-build-utils/.github/pkg-workflows/qli-ci/$workflow_name"
+              if [[ ! -f "$workflow" ]]; then
+                echo "    ❌ Missing workflow template in qcom-build-utils: $workflow_name"
+                exit 1
+              fi
 
               target_workflow=".github/workflows/$workflow_name"
 
@@ -238,6 +263,19 @@ jobs:
                       echo "      - $workflow_file"
                       rm -f "$workflow_file"
                     done <<< "$pr_target_workflows"
+                    isCleanupDirty=true
+                  fi
+
+                  debusine_workflows=$(find .github/workflows -maxdepth 1 -type f \
+                    \( -name 'debusine-*.yml' -o -name 'debusine-*.yaml' \) \
+                    | sort || true)
+                  if [[ -n "$debusine_workflows" ]]; then
+                    echo "    🗑️ Removing legacy debusine-* workflows on $other_branch"
+                    while IFS= read -r workflow_file; do
+                      [[ -z "$workflow_file" ]] && continue
+                      echo "      - $workflow_file"
+                      rm -f "$workflow_file"
+                    done <<< "$debusine_workflows"
                     isCleanupDirty=true
                   fi
                 fi
@@ -324,6 +362,19 @@ jobs:
                       echo "      - $workflow_file"
                       rm -f "$workflow_file"
                     done <<< "$pr_target_workflows"
+                    isDebianDirty=true
+                  fi
+
+                  debusine_workflows=$(find .github/workflows -maxdepth 1 -type f \
+                    \( -name 'debusine-*.yml' -o -name 'debusine-*.yaml' \) \
+                    | sort || true)
+                  if [[ -n "$debusine_workflows" ]]; then
+                    echo "    🗑️ Removing legacy debusine-* workflows on $packaging_branch"
+                    while IFS= read -r workflow_file; do
+                      [[ -z "$workflow_file" ]] && continue
+                      echo "      - $workflow_file"
+                      rm -f "$workflow_file"
+                    done <<< "$debusine_workflows"
                     isDebianDirty=true
                   fi
                 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Expected values:
 
 Examples:
 
-- `qcom/debian/latest` (normalized to suite `sid`)
+- `qcom/debian/latest` (normalized to Debusine suite `forky`; Docker fallback uses `sid`)
 - `qcom/debian/bookworm`
 - `qcom/ubuntu/resolute`
 - `test/qcom/ubuntu/resolute`

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Branch parsing rule:
 
 Examples:
 
-- `qcom/debian/latest` (maps to `sid`)
+- `qcom/debian/latest` (maps to Debusine suite `forky`; Docker fallback uses `sid`)
 - `qcom/debian/bookworm`
 - `qcom/ubuntu/resolute`
 - `test/qcom/ubuntu/resolute`


### PR DESCRIPTION
The next-UNRELEASED changelog bump step in `pkg-release-reusable-workflow.yml` requires the debian revision to be purely numeric, and fails for revisions with a non-numeric prefix.

This commit adds support to increment versions from 0qcom1 to 0qcom2~ and so on.
