### PR TITLE
ci: fix high-severity zizmor findings

### DIFF
--- a/.github/actions/abi_checker/action.yml
+++ b/.github/actions/abi_checker/action.yml
@@ -16,24 +16,29 @@ runs:
     - name : List All The Versions Of The Built Packages Contained In The Staging PPA
       if: false # Disable for now
       shell: bash
+      env:
+        INPUTS_APT_REPOSITORY: ${{ inputs.apt-repository }}
+        BUILT_PACKAGE_NAME: ${{ env.BUILT_PACKAGE_NAME }}
       run: |
         set +e
         ./qcom-build-utils/scripts/ppa_interface.py \
           --operation list-versions \
-          --apt-config "${{inputs.apt-repository}}" \
-          --package-name ${{env.BUILT_PACKAGE_NAME}}
+          --apt-config "${INPUTS_APT_REPOSITORY}" \
+          --package-name "${BUILT_PACKAGE_NAME}"
 
         RET=$?
         set -e
 
     - name: ABI Check
       shell: bash
+      env:
+        INPUTS_APT_REPOSITORY: ${{inputs.apt-repository}}
       run: |
         set +e
 
         ./qcom-build-utils/scripts/deb_abi_checker.py \
           --new-package-dir ./build-area \
-          --apt-server-config "${{inputs.apt-repository}}" \
+          --apt-server-config "${INPUTS_APT_REPOSITORY}" \
           --result-file ./results.txt
 
         RET=$?

--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -59,29 +59,34 @@ runs:
 
     - name: Detect Package Type
       shell: bash
+      env:
+        INPUTS_PREBUILT: ${{inputs.prebuilt}}
+        INPUTS_PKG_DIR: ${{inputs.pkg-dir}}
       run: |
-        if [[ "${{inputs.prebuilt}}" == "true" ]]; then
+        if [[ "${INPUTS_PREBUILT}" == "true" ]]; then
           echo "PREBUILT_MODE=true" >> $GITHUB_ENV
           echo "ℹ️ Build mode: prebuilt (explicitly set)"
-        elif [[ "${{inputs.prebuilt}}" == "false" ]]; then
+        elif [[ "${INPUTS_PREBUILT}" == "false" ]]; then
           echo "PREBUILT_MODE=false" >> $GITHUB_ENV
           echo "ℹ️ Build mode: source (explicitly set)"
         else
           # Auto-detect based on presence of upstream.conf in the package directory
-          if [[ -f "${{inputs.pkg-dir}}/upstream.conf" ]]; then
+          if [[ -f "${INPUTS_PKG_DIR}/upstream.conf" ]]; then
             echo "PREBUILT_MODE=true" >> $GITHUB_ENV
-            echo "ℹ️ Build mode: prebuilt (auto-detected: upstream.conf found in ${{inputs.pkg-dir}})"
+            echo "ℹ️ Build mode: prebuilt (auto-detected: upstream.conf found in ${INPUTS_PKG_DIR})"
           else
             echo "PREBUILT_MODE=false" >> $GITHUB_ENV
-            echo "ℹ️ Build mode: source (auto-detected: no upstream.conf in ${{inputs.pkg-dir}})"
+            echo "ℹ️ Build mode: source (auto-detected: no upstream.conf in ${INPUTS_PKG_DIR})"
           fi
         fi
 
     - name: Download Prebuilt Binary Archive
       if: ${{ env.PREBUILT_MODE == 'true' }}
       shell: bash
+      env:
+        INPUTS_PKG_DIR: ${{inputs.pkg-dir}}
       run: |
-        UPSTREAM_CONF="${{inputs.pkg-dir}}/upstream.conf"
+        UPSTREAM_CONF="${INPUTS_PKG_DIR}/upstream.conf"
 
         if [[ ! -f "$UPSTREAM_CONF" ]]; then
           echo "❌ upstream.conf not found at $UPSTREAM_CONF"
@@ -109,28 +114,30 @@ runs:
         echo "   File : $PACKAGE_NAME"
 
         curl --fail --show-error --location \
-             --output "${{inputs.pkg-dir}}/$PACKAGE_NAME" \
+             --output "${INPUTS_PKG_DIR}/$PACKAGE_NAME" \
              "$DOWNLOAD_URL"
 
         if [[ -n "$PACKAGE_SHA256" ]]; then
           echo "ℹ️ Verifying SHA256 checksum..."
-          echo "$PACKAGE_SHA256  ${{inputs.pkg-dir}}/$PACKAGE_NAME" | sha256sum --check
+          echo "$PACKAGE_SHA256  ${INPUTS_PKG_DIR}/$PACKAGE_NAME" | sha256sum --check
           echo "✅ Checksum verified"
         else
           echo "⚠️ No PACKAGE_SHA256 defined in upstream.conf — skipping checksum verification"
         fi
 
-        echo "ℹ️ Extracting $PACKAGE_NAME into ${{inputs.pkg-dir}}/"
-        tar -xf "${{inputs.pkg-dir}}/$PACKAGE_NAME" -C "${{inputs.pkg-dir}}"
-        rm -f "${{inputs.pkg-dir}}/$PACKAGE_NAME"
+        echo "ℹ️ Extracting $PACKAGE_NAME into ${INPUTS_PKG_DIR}/"
+        tar -xf "${INPUTS_PKG_DIR}/$PACKAGE_NAME" -C "${INPUTS_PKG_DIR}"
+        rm -f "${INPUTS_PKG_DIR}/$PACKAGE_NAME"
         echo "✅ Prebuilt archive extracted successfully"
 
     - name: Prepare Workspace Structure For The Build
       shell: bash
+      env:
+        INPUTS_BUILD_DIR: ${{inputs.build-dir}}
       run: |
         echo "Listing the content of the workspace :"; tree
 
-        mkdir -p ${{inputs.build-dir}}
+        mkdir -p ${INPUTS_BUILD_DIR}
 
         if grep -q 'quilt' ./package-repo/debian/source/format; then
           echo "Source format is quilt"
@@ -143,14 +150,19 @@ runs:
 
     - name : Build Package
       shell: bash
+      env:
+        INPUTS_PKG_DIR: ${{inputs.pkg-dir}}
+        INPUTS_RUN_LINTIAN: ${{inputs.run-lintian}}
+        INPUTS_BUILD_DIR: ${{inputs.build-dir}}
+        INPUTS_SUITE: ${{inputs.suite}}
       run: |
-        cd ${{inputs.pkg-dir}}
+        cd ${INPUTS_PKG_DIR}
 
         # GitHub Actions container jobs use HOME=/github/home by default, but the
         # builder images bake the sbuild config and unshare tarballs under /root.
         export HOME=/root
 
-        if [[ "${{inputs.run-lintian}}" == "true" ]]; then
+        if [[ "${INPUTS_RUN_LINTIAN}" == "true" ]]; then
           lintian_flag="--run-lintian"
         else
           lintian_flag="--no-run-lintian"
@@ -158,7 +170,7 @@ runs:
 
         # Resolve the build output directory to an absolute path now, before any
         # subsequent cd operations might change the working directory.
-        BUILD_DIR_ABS=$(realpath "../${{inputs.build-dir}}")
+        BUILD_DIR_ABS=$(realpath "../${INPUTS_BUILD_DIR}")
 
         set +e
 
@@ -196,9 +208,9 @@ runs:
             # Host Architecture: The architecture for which the binaries are being built (invariably arm64).
             sbuild --no-clean-source \
                    --host=arm64 \
-                   --build=${{env.BUILD_ARCH}} \
+                   --build=${BUILD_ARCH} \
                    --arch-all \
-                   --dist=${{inputs.suite}} \
+                   --dist=${INPUTS_SUITE} \
                    $lintian_flag \
                    --build-dir "$BUILD_DIR_ABS" \
                    --build-dep-resolver=apt \
@@ -209,9 +221,9 @@ runs:
             # Host Architecture: The architecture for which the binaries are being built (invariably arm64).
             sbuild --no-clean-source \
                    --host=arm64 \
-                   --build=${{env.BUILD_ARCH}} \
+                   --build=${BUILD_ARCH} \
                    --arch-all \
-                   --dist=${{inputs.suite}} \
+                   --dist=${INPUTS_SUITE} \
                    $lintian_flag \
                    --build-dir "$BUILD_DIR_ABS" \
                    --build-dep-resolver=apt
@@ -266,9 +278,9 @@ runs:
 
           sbuild --no-clean-source \
                  --host=arm64 \
-                 --build=${{env.BUILD_ARCH}} \
+                 --build=${BUILD_ARCH} \
                  --arch-all \
-                 --dist=${{inputs.suite}} \
+                 --dist=${INPUTS_SUITE} \
                  $lintian_flag \
                  --build-dir "$BUILD_DIR_ABS" \
                  --build-dep-resolver=apt \

--- a/.github/actions/push_to_repo/action.yml
+++ b/.github/actions/push_to_repo/action.yml
@@ -16,10 +16,6 @@ inputs:
     description: If the version of the package already exists, override it.
     default: false
 
-env:
-  BUILT_PACKAGE_NAME: null
-  BUILT_PACKAGE_VERSION: null
-
 runs:
   using: "composite"
   
@@ -27,6 +23,7 @@ runs:
 
     # TODO deal with the case where multiple packages are built
     - name: Extract built package name
+      id: extract-built-package
       shell: bash
       run: |
         changes_file=$(find ./build-area -maxdepth 1 -name '*.changes' | head -n 1)
@@ -55,20 +52,23 @@ runs:
 
         version=$(grep '^Version:' "$changes_file" | sed 's/^Version: //')
         
-        echo "BUILT_PACKAGE_NAME=$main_binary" >> $GITHUB_ENV
-        echo "BUILT_PACKAGE_VERSION=$version" >> $GITHUB_ENV
+        echo "built_package_name=$main_binary" >> "$GITHUB_OUTPUT"
+        echo "built_package_version=$version" >> "$GITHUB_OUTPUT"
         
         echo "Built package name : $main_binary"
         echo "Built package version : $version"
 
     - name : List All The Versions Of The Built Packages Contained In The Staging PPA
       shell: bash
+      env:
+        INPUTS_DISTRO_CODENAME: ${{inputs.distro-codename}}
+        BUILT_PACKAGE_NAME: ${{steps.extract-built-package.outputs.built_package_name}}
       run: |
         set +e
         ./qcom-build-utils/scripts/ppa_interface.py \
           --operation list-versions \
-          --apt-config "deb [arch=arm64 trusted=yes] ${{env.REPO_URL}} ${{inputs.distro-codename}}/stable main" \
-          --package-name ${{env.BUILT_PACKAGE_NAME}}
+          --apt-config "deb [arch=arm64 trusted=yes] ${REPO_URL} ${INPUTS_DISTRO_CODENAME}/stable main" \
+          --package-name ${BUILT_PACKAGE_NAME}
 
         RET=$?
         set -e
@@ -76,25 +76,30 @@ runs:
     - name: Check If Need To Upload To Repo
       id: check-version
       shell: bash
+      env:
+        INPUTS_DISTRO_CODENAME: ${{inputs.distro-codename}}
+        INPUTS_FORCE_OVERRIDE: ${{inputs.force-override}}
+        BUILT_PACKAGE_NAME: ${{steps.extract-built-package.outputs.built_package_name}}
+        BUILT_PACKAGE_VERSION: ${{steps.extract-built-package.outputs.built_package_version}}
       run: |
         echo "Checking if the repo already contains the built version"
 
         set +e
         ./qcom-build-utils/scripts/ppa_interface.py \
           --operation contains-version \
-          --apt-config "deb [arch=arm64 trusted=yes] ${{env.REPO_URL}} ${{inputs.distro-codename}}/stable main" \
-          --package-name ${{env.BUILT_PACKAGE_NAME}} \
-          --version ${{env.BUILT_PACKAGE_VERSION}}
+          --apt-config "deb [arch=arm64 trusted=yes] ${REPO_URL} ${INPUTS_DISTRO_CODENAME}/stable main" \
+          --package-name ${BUILT_PACKAGE_NAME} \
+          --version ${BUILT_PACKAGE_VERSION}
 
         RET=$?
         set -e
 
         echo "do_upload=true" >> $GITHUB_OUTPUT
 
-        if [[ "$RET" == "0" && "${{inputs.force-override}}" == "false" ]]; then
+        if [[ "$RET" == "0" && "${INPUTS_FORCE_OVERRIDE}" == "false" ]]; then
           echo "Package version already exists in the repo and force-override is set to false. We are therefore done here."
           echo "do_upload=false" >> $GITHUB_OUTPUT
-        elif [[ "$RET" == "0" && "${{inputs.force-override}}" == "true" ]]; then
+        elif [[ "$RET" == "0" && "${INPUTS_FORCE_OVERRIDE}" == "true" ]]; then
           echo "Package version already exists in the repo, but force-override is set to true. Proceeding to override the package"
         else
           echo "The package version does not exist in the repo. Proceeding to uploat it."
@@ -113,15 +118,20 @@ runs:
     - name: Upload Debian Packages To Staging Repo
       if: steps.check-version.outputs.do_upload == 'true'
       shell: bash
+      env:
+        INPUTS_DISTRO_CODENAME: ${{inputs.distro-codename}}
+        INPUTS_TOKEN: ${{inputs.token}}
+        BUILT_PACKAGE_NAME: ${{steps.extract-built-package.outputs.built_package_name}}
+        BUILT_PACKAGE_VERSION: ${{steps.extract-built-package.outputs.built_package_version}}
       run: |
-        ./qcom-build-utils/scripts/ppa_organizer.py --build-dir ./build-area --output-dir ./pkg-oss-staging-repo/pool/${{inputs.distro-codename}}/stable/main
+        ./qcom-build-utils/scripts/ppa_organizer.py --build-dir ./build-area --output-dir ./pkg-oss-staging-repo/pool/${INPUTS_DISTRO_CODENAME}/stable/main
 
         cd ./pkg-oss-staging-repo
 
-        PPA_PACKAGES_FILE_REPO_PATH=dists/${{inputs.distro-codename}}/stable/main/binary-arm64
+        PPA_PACKAGES_FILE_REPO_PATH=dists/${INPUTS_DISTRO_CODENAME}/stable/main/binary-arm64
 
-        dpkg-scanpackages --multiversion pool/${{inputs.distro-codename}} > $PPA_PACKAGES_FILE_REPO_PATH/Packages
-        dpkg-scanpackages --type ddeb --multiversion pool/${{inputs.distro-codename}} >> $PPA_PACKAGES_FILE_REPO_PATH/Packages
+        dpkg-scanpackages --multiversion pool/${INPUTS_DISTRO_CODENAME} > $PPA_PACKAGES_FILE_REPO_PATH/Packages
+        dpkg-scanpackages --type ddeb --multiversion pool/${INPUTS_DISTRO_CODENAME} >> $PPA_PACKAGES_FILE_REPO_PATH/Packages
 
         gzip -k -f $PPA_PACKAGES_FILE_REPO_PATH/Packages
 
@@ -132,8 +142,8 @@ runs:
         git config user.name "GitHub Service Bot"
         git config user.email "githubservice@qti.qualcomm.com"
 
-        git commit -s -m "Uploaded Package ${{env.BUILT_PACKAGE_NAME}} at version ${{env.BUILT_PACKAGE_VERSION}} for distro ${{inputs.distro-codename}}"
+        git commit -s -m "Uploaded Package ${BUILT_PACKAGE_NAME} at version ${BUILT_PACKAGE_VERSION} for distro ${INPUTS_DISTRO_CODENAME}"
 
-        git remote set-url origin https://x-access-token:${{inputs.token}}@github.com/${{env.REPO_NAME}}.git
+        git remote set-url origin https://x-access-token:${INPUTS_TOKEN}@github.com/${REPO_NAME}.git
 
         git push origin

--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -344,8 +344,10 @@ jobs:
           echo "workspace_url=https://${DEBUSINE_HOST}/${DEBUSINE_SCOPE}/${workspace}/" >> "$GITHUB_OUTPUT"
 
       - name: Note Debusine workspace URL
+        env:
+          STEPS_PREPARE_DEBUSINE_OUTPUTS_WORKSPACE_URL: ${{ steps.prepare-debusine.outputs.workspace_url }}
         run: |
-          echo "Debusine Workspace URL: ${{ steps.prepare-debusine.outputs.workspace_url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Debusine Workspace URL: ${STEPS_PREPARE_DEBUSINE_OUTPUTS_WORKSPACE_URL}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release bundle
         if: ${{ inputs.release }}
@@ -385,7 +387,7 @@ jobs:
       srcpkg_version: ${{ steps.select.outputs.srcpkg_version }}
     runs-on: ubuntu-24.04-arm
     container:
-      image: ${{ format('ghcr.io/qualcomm-linux/pkg-builder:{0}', needs.resolve.outputs.suite) }}
+      image: ${{ format('ghcr.io/qualcomm-linux/pkg-builder:{0}', needs.resolve.outputs.suite) }} # zizmor: ignore[unpinned-images] Dynamic suite-driven image tag is required for hybrid Ubuntu builder routing.
       options: --user 0:0
       credentials:
         username: ${{ github.actor }}
@@ -503,11 +505,13 @@ jobs:
       - name: Validate installability from Docker build artifacts
         # Temporarily disabled while dependency repository injection is unresolved.
         if: ${{ false }}
+        env:
+          SUITE: ${{ needs.resolve.outputs.suite }}
         run: |
           set -euxo pipefail
 
           # Add qsc-deb-releases so Qualcomm package dependencies are resolvable
-          suite="${{ needs.resolve.outputs.suite }}"
+          suite="${SUITE}"
           install -d /etc/apt/keyrings /etc/apt/sources.list.d
           cat > /etc/apt/keyrings/qsc-deb-releases.asc <<'KEYEOF'
           -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -546,17 +550,26 @@ jobs:
 
       - name: Select test outputs
         id: select
+        env:
+          NEEDS_RESOLVE_OUTPUTS_FAMILY: ${{ needs.resolve.outputs.family }}
+          NEEDS_RESOLVE_OUTPUTS_FORCE_DOCKER_BUILD: ${{ needs.resolve.outputs.force_docker_build }}
+          NEEDS_DEBIAN_BUILD_OUTPUTS_WORKSPACE: ${{ needs.debian-build.outputs.workspace }}
+          NEEDS_DEBIAN_BUILD_OUTPUTS_WORKSPACE_URL: ${{ needs.debian-build.outputs.workspace_url }}
+          NEEDS_DEBIAN_BUILD_OUTPUTS_SRCPKG_NAME: ${{ needs.debian-build.outputs.srcpkg_name }}
+          NEEDS_DEBIAN_BUILD_OUTPUTS_SRCPKG_VERSION: ${{ needs.debian-build.outputs.srcpkg_version }}
+          NEEDS_DOCKER_BUILD_OUTPUTS_SRCPKG_NAME: ${{ needs.docker-build.outputs.srcpkg_name }}
+          NEEDS_DOCKER_BUILD_OUTPUTS_SRCPKG_VERSION: ${{ needs.docker-build.outputs.srcpkg_version }}
         run: |
-          if [[ "${{ needs.resolve.outputs.family }}" == "debian" && "${{ needs.resolve.outputs.force_docker_build }}" != "true" ]]; then
-            echo "workspace=${{ needs.debian-build.outputs.workspace }}" >> "$GITHUB_OUTPUT"
-            echo "workspace_url=${{ needs.debian-build.outputs.workspace_url }}" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_name=${{ needs.debian-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_version=${{ needs.debian-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+          if [[ "${NEEDS_RESOLVE_OUTPUTS_FAMILY}" == "debian" && "${NEEDS_RESOLVE_OUTPUTS_FORCE_DOCKER_BUILD}" != "true" ]]; then
+            echo "workspace=${NEEDS_DEBIAN_BUILD_OUTPUTS_WORKSPACE}" >> "$GITHUB_OUTPUT"
+            echo "workspace_url=${NEEDS_DEBIAN_BUILD_OUTPUTS_WORKSPACE_URL}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_name=${NEEDS_DEBIAN_BUILD_OUTPUTS_SRCPKG_NAME}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_version=${NEEDS_DEBIAN_BUILD_OUTPUTS_SRCPKG_VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "workspace=" >> "$GITHUB_OUTPUT"
             echo "workspace_url=" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_name=${{ needs.docker-build.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
-            echo "srcpkg_version=${{ needs.docker-build.outputs.srcpkg_version }}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_name=${NEEDS_DOCKER_BUILD_OUTPUTS_SRCPKG_NAME}" >> "$GITHUB_OUTPUT"
+            echo "srcpkg_version=${NEEDS_DOCKER_BUILD_OUTPUTS_SRCPKG_VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Note temporary installability policy

--- a/.github/workflows/pkg-promote-prebuilt-reusable-workflow.yml
+++ b/.github/workflows/pkg-promote-prebuilt-reusable-workflow.yml
@@ -89,10 +89,13 @@ jobs:
           fetch-tags: true
 
       - name: Validate and Read Current upstream.conf
+        env:
+          INPUTS_DEBIAN_BRANCH: ${{inputs.debian-branch}}
+          INPUTS_NEW_TAG: ${{inputs.new-tag}}
         run: |
           cd ./package-repo
 
-          git checkout ${{inputs.debian-branch}}
+          git checkout ${INPUTS_DEBIAN_BRANCH}
 
           if [[ ! -f "upstream.conf" ]]; then
             echo "❌ upstream.conf not found in the repository root."
@@ -115,8 +118,8 @@ jobs:
           echo "   DISTRO       : $DISTRO"
           echo "   PACKAGE_NAME : $PACKAGE_NAME"
 
-          if [[ "$TAG" == "${{inputs.new-tag}}" ]]; then
-            echo "❌ The new-tag '${{inputs.new-tag}}' is identical to the current TAG '$TAG' in upstream.conf."
+          if [[ "$TAG" == "${INPUTS_NEW_TAG}" ]]; then
+            echo "❌ The new-tag '${INPUTS_NEW_TAG}' is identical to the current TAG '$TAG' in upstream.conf."
             echo "   Nothing to promote."
             exit 1
           fi
@@ -127,20 +130,24 @@ jobs:
           echo "DISTRO=$DISTRO"               >> $GITHUB_ENV
 
       - name: Resolve New Package Name and Debian Version
+        env:
+          INPUTS_NEW_PACKAGE_NAME: ${{inputs.new-package-name}}
+          INPUTS_NEW_DEBIAN_VERSION: ${{inputs.new-debian-version}}
+          INPUTS_NEW_TAG: ${{inputs.new-tag}}
         run: |
           # Determine the effective new PACKAGE_NAME
-          if [[ -n "${{inputs.new-package-name}}" ]]; then
-            NEW_PACKAGE_NAME="${{inputs.new-package-name}}"
+          if [[ -n "${INPUTS_NEW_PACKAGE_NAME}" ]]; then
+            NEW_PACKAGE_NAME="${INPUTS_NEW_PACKAGE_NAME}"
             echo "ℹ️ Using provided new-package-name: $NEW_PACKAGE_NAME"
           else
-            NEW_PACKAGE_NAME="${{env.CURRENT_PACKAGE_NAME}}"
+            NEW_PACKAGE_NAME="${CURRENT_PACKAGE_NAME}"
             echo "ℹ️ No new-package-name provided, keeping current: $NEW_PACKAGE_NAME"
           fi
           echo "NEW_PACKAGE_NAME=$NEW_PACKAGE_NAME" >> $GITHUB_ENV
 
           # Determine the debian changelog version
-          if [[ -n "${{inputs.new-debian-version}}" ]]; then
-            NEW_DEBIAN_VERSION="${{inputs.new-debian-version}}"
+          if [[ -n "${INPUTS_NEW_DEBIAN_VERSION}" ]]; then
+            NEW_DEBIAN_VERSION="${INPUTS_NEW_DEBIAN_VERSION}"
             echo "ℹ️ Using provided new-debian-version: $NEW_DEBIAN_VERSION"
           else
             # Derive version from PACKAGE_NAME: extract the part between the first and second underscore.
@@ -162,14 +169,16 @@ jobs:
           echo "PR_BRANCH=debian/pr/${BRANCH_VERSION}" >> $GITHUB_ENV
 
           echo "ℹ️ Promotion summary:"
-          echo "   TAG          : ${{env.CURRENT_TAG}} → ${{inputs.new-tag}}"
-          echo "   PACKAGE_NAME : ${{env.CURRENT_PACKAGE_NAME}} → $NEW_PACKAGE_NAME"
+          echo "   TAG          : ${CURRENT_TAG} → ${INPUTS_NEW_TAG}"
+          echo "   PACKAGE_NAME : ${CURRENT_PACKAGE_NAME} → $NEW_PACKAGE_NAME"
           echo "   Debian ver   : $NEW_DEBIAN_VERSION"
           echo "   PR branch    : debian/pr/${BRANCH_VERSION}"
 
       - name: Verify New Tarball Exists on Artifactory
+        env:
+          INPUTS_NEW_TAG: ${{inputs.new-tag}}
         run: |
-          DOWNLOAD_URL="${{env.ARTIFACTORY}}/${{inputs.new-tag}}/${{env.DISTRO}}/${{env.NEW_PACKAGE_NAME}}"
+          DOWNLOAD_URL="${ARTIFACTORY}/${INPUTS_NEW_TAG}/${DISTRO}/${NEW_PACKAGE_NAME}"
           echo "ℹ️ Verifying tarball exists at: $DOWNLOAD_URL"
 
           if curl --head --fail --silent --show-error "$DOWNLOAD_URL"; then
@@ -181,58 +190,71 @@ jobs:
           fi
 
       - name: Create Promotion Branch and Update upstream.conf
+        env:
+          VARS_DEB_PKG_BOT_CI_NAME: ${{vars.DEB_PKG_BOT_CI_NAME}}
+          VARS_DEB_PKG_BOT_CI_EMAIL: ${{vars.DEB_PKG_BOT_CI_EMAIL}}
+          INPUTS_NEW_TAG: ${{inputs.new-tag}}
         run: |
           cd ./package-repo
 
-          git config user.name "${{vars.DEB_PKG_BOT_CI_NAME}}"
-          git config user.email "${{vars.DEB_PKG_BOT_CI_EMAIL}}"
+          git config user.name "${VARS_DEB_PKG_BOT_CI_NAME}"
+          git config user.email "${VARS_DEB_PKG_BOT_CI_EMAIL}"
 
-          git checkout -b ${{env.PR_BRANCH}}
+          git checkout -b ${PR_BRANCH}
 
           # Update TAG in upstream.conf
-          sed -i "s|^export TAG=.*|export TAG=\"${{inputs.new-tag}}\"|" upstream.conf
+          sed -i "s|^export TAG=.*|export TAG=\"${INPUTS_NEW_TAG}\"|" upstream.conf
 
           # Update PACKAGE_NAME in upstream.conf only if it changed
-          if [[ "${{env.NEW_PACKAGE_NAME}}" != "${{env.CURRENT_PACKAGE_NAME}}" ]]; then
-            sed -i "s|^export PACKAGE_NAME=.*|export PACKAGE_NAME=\"${{env.NEW_PACKAGE_NAME}}\"|" upstream.conf
+          if [[ "${NEW_PACKAGE_NAME}" != "${CURRENT_PACKAGE_NAME}" ]]; then
+            sed -i "s|^export PACKAGE_NAME=.*|export PACKAGE_NAME=\"${NEW_PACKAGE_NAME}\"|" upstream.conf
           fi
 
           echo "ℹ️ Updated upstream.conf:"
           cat upstream.conf | sed 's/^/   /'
 
       - name: Bump Debian Changelog
+        env:
+          VARS_DEB_PKG_BOT_CI_NAME: ${{vars.DEB_PKG_BOT_CI_NAME}}
+          VARS_DEB_PKG_BOT_CI_EMAIL: ${{vars.DEB_PKG_BOT_CI_EMAIL}}
+          INPUTS_NEW_TAG: ${{inputs.new-tag}}
         run: |
           cd ./package-repo
 
-          export DEBFULLNAME="${{vars.DEB_PKG_BOT_CI_NAME}}"
-          export DEBEMAIL="${{vars.DEB_PKG_BOT_CI_EMAIL}}"
+          export DEBFULLNAME="${VARS_DEB_PKG_BOT_CI_NAME}"
+          export DEBEMAIL="${VARS_DEB_PKG_BOT_CI_EMAIL}"
 
           dch \
-            --newversion="${{env.NEW_DEBIAN_VERSION}}" \
+            --newversion="${NEW_DEBIAN_VERSION}" \
             --distribution=UNRELEASED \
-            "New upstream release (Artifactory tag: ${{inputs.new-tag}})"
+            "New upstream release (Artifactory tag: ${INPUTS_NEW_TAG})"
 
           echo "ℹ️ Updated debian/changelog (first 5 lines):"
           head -5 debian/changelog | sed 's/^/   /'
 
       - name: Commit and Push Promotion Branch
+        env:
+          INPUTS_NEW_TAG: ${{inputs.new-tag}}
         run: |
           cd ./package-repo
 
           git add upstream.conf debian/changelog
-          git commit -s -m "Promote to Artifactory tag ${{inputs.new-tag}} (version ${{env.NEW_DEBIAN_VERSION}})"
+          git commit -s -m "Promote to Artifactory tag ${INPUTS_NEW_TAG} (version ${NEW_DEBIAN_VERSION})"
 
-          git push origin ${{env.PR_BRANCH}}
+          git push origin ${PR_BRANCH}
 
           git log --graph --oneline -n 5 --color=always
 
       - name: Open Promotion PR
+        env:
+          INPUTS_NEW_TAG: ${{inputs.new-tag}}
+          INPUTS_DEBIAN_BRANCH: ${{inputs.debian-branch}}
         run: |
           cd ./package-repo
 
           gh auth login --with-token <<< "${{secrets.DEB_PKG_BOT_CI_TOKEN}}"
 
-          PR_TITLE="Promotion to ${{env.NEW_DEBIAN_VERSION}} (Artifactory tag: ${{inputs.new-tag}})"
+          PR_TITLE="Promotion to ${NEW_DEBIAN_VERSION} (Artifactory tag: ${INPUTS_NEW_TAG})"
 
           PR_BODY=$(cat <<EOF
           ## Automated Prebuilt Binary Promotion PR
@@ -243,12 +265,12 @@ jobs:
 
           | Field | Old | New |
           |---|---|---|
-          | Artifactory TAG | \`${{env.CURRENT_TAG}}\` | \`${{inputs.new-tag}}\` |
-          | PACKAGE_NAME | \`${{env.CURRENT_PACKAGE_NAME}}\` | \`${{env.NEW_PACKAGE_NAME}}\` |
-          | Debian version | (previous) | \`${{env.NEW_DEBIAN_VERSION}}\` |
+          | Artifactory TAG | \`${CURRENT_TAG}\` | \`${INPUTS_NEW_TAG}\` |
+          | PACKAGE_NAME | \`${CURRENT_PACKAGE_NAME}\` | \`${NEW_PACKAGE_NAME}\` |
+          | Debian version | (previous) | \`${NEW_DEBIAN_VERSION}\` |
 
           ### Tarball verified at
-          \`${{env.ARTIFACTORY}}/${{inputs.new-tag}}/${{env.DISTRO}}/${{env.NEW_PACKAGE_NAME}}\`
+          \`${ARTIFACTORY}/${INPUTS_NEW_TAG}/${DISTRO}/${NEW_PACKAGE_NAME}\`
 
           ### What happens next
           1. The **PR Pre and Post Merge Build** workflow is triggered automatically on this PR
@@ -262,5 +284,5 @@ jobs:
           gh pr create \
             --title "$PR_TITLE" \
             --body "$PR_BODY" \
-            --base ${{inputs.debian-branch}} \
-            --head ${{env.PR_BRANCH}}
+            --base ${INPUTS_DEBIAN_BRANCH} \
+            --head ${PR_BRANCH}

--- a/.github/workflows/pkg-promote-reusable-workflow.yml
+++ b/.github/workflows/pkg-promote-reusable-workflow.yml
@@ -66,10 +66,12 @@ jobs:
 
       # Normalizing a tag : (e.g ) v1.0.0 -> 1.0.0
       - name: Normalize Tag Version
+        env:
+          INPUTS_UPSTREAM_TAG: ${{inputs.upstream-tag}}
         run: |
-          echo "ℹ️ Input upstream-tag is : ${{inputs.upstream-tag}}"
+          echo "ℹ️ Input upstream-tag is : ${INPUTS_UPSTREAM_TAG}"
 
-          NORMALIZED_VERSION=$(echo "${{inputs.upstream-tag}}" | sed 's/^v//')
+          NORMALIZED_VERSION=$(echo "${INPUTS_UPSTREAM_TAG}" | sed 's/^v//')
           echo "NORMALIZED_VERSION=$NORMALIZED_VERSION" >> $GITHUB_ENV
 
           echo "ℹ️ Normalized version : $NORMALIZED_VERSION"
@@ -99,10 +101,12 @@ jobs:
 
       - name: Show branches/tags and checkout debian/upstream latest
         working-directory: ./package-repo
+        env:
+          INPUTS_DEBIAN_BRANCH: ${{inputs.debian-branch}}
         run: |
           git branch
           git tag
-          git checkout ${{inputs.debian-branch}}
+          git checkout ${INPUTS_DEBIAN_BRANCH}
           echo "Listing all the current tags :"
           git tag --list
           if git ls-remote --exit-code --heads origin upstream/latest; then
@@ -153,22 +157,26 @@ jobs:
 
       - name: Make sure the upstream tag is not already part of the repo
         working-directory: ./package-repo
+        env:
+          INPUTS_UPSTREAM_TAG: ${{inputs.upstream-tag}}
         run: |
-          if (git tag --list | grep "${{inputs.upstream-tag}}"); then
+          if (git tag --list | grep "${INPUTS_UPSTREAM_TAG}"); then
             echo "❌ The supplied upstream tag is wrong as it pertains to this repo already."
             exit 1
           fi
 
       - name: Validate the upstream tag promotion state
         working-directory: ./package-repo
+        env:
+          INPUTS_UPSTREAM_TAG: ${{inputs.upstream-tag}}
         run: |
           # Check if the resolved promoted tag does not already exist
           if ! git rev-parse --verify "refs/tags/${{env.UPSTREAM_PROMOTED_TAG}}" >/dev/null 2>&1; then
-            echo "✅ The upstream tag '${{inputs.upstream-tag}}' has not been promoted yet. Continuing."
+            echo "✅ The upstream tag '${INPUTS_UPSTREAM_TAG}' has not been promoted yet. Continuing."
             exit 0
           fi
 
-          echo "⚠️ It appears like this repo has already integrated the upstream tag '${{inputs.upstream-tag}}' as '${{env.UPSTREAM_PROMOTED_TAG}}'"
+          echo "⚠️ It appears like this repo has already integrated the upstream tag '${INPUTS_UPSTREAM_TAG}' as '${{env.UPSTREAM_PROMOTED_TAG}}'"
 
           PROMOTED_TAG_GLOB="${{env.UPSTREAM_TAG_TEMPLATE}}"
           PROMOTED_TAG_GLOB="${PROMOTED_TAG_GLOB//%(version)s/*}"
@@ -216,13 +224,15 @@ jobs:
 
       - name: Add Upstream Link As A Remote And Fetch Tags
         working-directory: ./package-repo
+        env:
+          INPUTS_UPSTREAM_REPO: ${{inputs.upstream-repo}}
         run: |
           if [ -n "${{secrets.PAT}}" ]; then
             echo "ℹ️ Adding upstream remote with token authentication. This is because the upstream repository may be private and require authentication to fetch tags."
-            REPO_URL=https://x-access-token:${{secrets.PAT}}@github.com/${{inputs.upstream-repo}}.git
+            REPO_URL=https://x-access-token:${{secrets.PAT}}@github.com/${INPUTS_UPSTREAM_REPO}.git
           else
             echo "ℹ️ Adding upstream remote without token authentication, repo is assumed to be public"
-            REPO_URL=https://github.com/${{inputs.upstream-repo}}.git
+            REPO_URL=https://github.com/${INPUTS_UPSTREAM_REPO}.git
           fi
 
           git remote add upstream-source $REPO_URL
@@ -232,7 +242,7 @@ jobs:
           # Override the global extraheader set by actions/checkout (GITHUB_TOKEN) which would otherwise
           # take precedence over the credentials embedded in the URL and prevent access to external repos.
           if ! git fetch upstream-source "+refs/tags/*:refs/tags/*"; then
-            echo "❌ Failed to fetch tags from '${{inputs.upstream-repo}}'."
+            echo "❌ Failed to fetch tags from '${INPUTS_UPSTREAM_REPO}'."
 
             if [ -n "${{secrets.PAT}}" ]; then
               echo "❌ Ensure that the PAT token has the  permission on the repository."
@@ -246,13 +256,17 @@ jobs:
 
       - name: Ensure the tag exists in the upstream repo
         working-directory: ./package-repo
+        env:
+          INPUTS_UPSTREAM_TAG: ${{inputs.upstream-tag}}
         run: |
-          if ! git rev-parse --verify "refs/tags/${{inputs.upstream-tag}}" >/dev/null 2>&1; then
-            echo "❌ The specified upstream tag '${{inputs.upstream-tag}}' does not exist in the upstream repository."
+          if ! git rev-parse --verify "refs/tags/${INPUTS_UPSTREAM_TAG}" >/dev/null 2>&1; then
+            echo "❌ The specified upstream tag '${INPUTS_UPSTREAM_TAG}' does not exist in the upstream repository."
             exit 1
           fi
 
       - name: Pre-populate the upstream/latest branch if first promotion
+        env:
+          INPUTS_UPSTREAM_TAG: ${{inputs.upstream-tag}}
         run: |
           cd ./package-repo
 
@@ -260,30 +274,38 @@ jobs:
           # the history of upstream directly, instead of creating an --allow-empty commit
           # which will be dragged along.
           if ! git ls-remote --exit-code --heads origin upstream/latest; then
-            git branch upstream/latest ${{inputs.upstream-tag}}
+            git branch upstream/latest ${INPUTS_UPSTREAM_TAG}
           else
             # The branch exists, check it out and promote it to the upstream tag
             git checkout upstream/latest
-            git merge --ff-only ${{inputs.upstream-tag}}
+            git merge --ff-only ${INPUTS_UPSTREAM_TAG}
           fi
 
       - name: Merge upstream tag into packaging branch
         working-directory: ./package-repo
+        env:
+          VARS_DEB_PKG_BOT_CI_NAME: ${{vars.DEB_PKG_BOT_CI_NAME}}
+          VARS_DEB_PKG_BOT_CI_EMAIL: ${{vars.DEB_PKG_BOT_CI_EMAIL}}
+          INPUTS_DEBIAN_BRANCH: ${{inputs.debian-branch}}
+          INPUTS_UPSTREAM_TAG: ${{inputs.upstream-tag}}
         run: |
-          git config user.name "${{vars.DEB_PKG_BOT_CI_NAME}}"
-          git config user.email "${{vars.DEB_PKG_BOT_CI_EMAIL}}"
+          git config user.name "${VARS_DEB_PKG_BOT_CI_NAME}"
+          git config user.email "${VARS_DEB_PKG_BOT_CI_EMAIL}"
 
-          git checkout ${{inputs.debian-branch}}
+          git checkout ${INPUTS_DEBIAN_BRANCH}
 
           git checkout -b debian/pr/${{env.NORMALIZED_VERSION}}-1
 
-          ../qcom-build-utils/scripts/merge_debian_packaging_upstream ${{inputs.upstream-tag}}
+          ../qcom-build-utils/scripts/merge_debian_packaging_upstream ${INPUTS_UPSTREAM_TAG}
 
       - name: Promote Changelog
         working-directory: ./package-repo
+        env:
+          VARS_DEB_PKG_BOT_CI_NAME: ${{vars.DEB_PKG_BOT_CI_NAME}}
+          VARS_DEB_PKG_BOT_CI_EMAIL: ${{vars.DEB_PKG_BOT_CI_EMAIL}}
         run: |
-          export DEBFULLNAME="${{vars.DEB_PKG_BOT_CI_NAME}}"
-          export DEBEMAIL="${{vars.DEB_PKG_BOT_CI_EMAIL}}"
+          export DEBFULLNAME="${VARS_DEB_PKG_BOT_CI_NAME}"
+          export DEBEMAIL="${VARS_DEB_PKG_BOT_CI_EMAIL}"
 
           # use ignore branch because we are not on default debian branch
           dch \
@@ -312,9 +334,12 @@ jobs:
 
       - name: Open Promotion PR
         working-directory: ./package-repo
+        env:
+          INPUTS_DEBIAN_BRANCH: ${{inputs.debian-branch}}
+          INPUTS_UPSTREAM_TAG: ${{inputs.upstream-tag}}
         run: |
           ../qcom-build-utils/scripts/create_promotion_pr.py \
-            --base-branch "${{inputs.debian-branch}}" \
-            --upstream-tag "${{inputs.upstream-tag}}" \
+            --base-branch "${INPUTS_DEBIAN_BRANCH}" \
+            --upstream-tag "${INPUTS_UPSTREAM_TAG}" \
             --normalized-version "${{env.NORMALIZED_VERSION}}" \
             --promoted-upstream-tag "${{env.UPSTREAM_PROMOTED_TAG}}"

--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -244,10 +244,13 @@ jobs:
 
       - name: Select source preparation outputs
         id: select
+        env:
+          STEPS_PREPARE_OUTPUTS_SRCPKG_NAME: ${{ steps.prepare.outputs.srcpkg_name }}
+          STEPS_PREPARE_OUTPUTS_RELEASE_VERSION: ${{ steps.prepare.outputs.release_version }}
         run: |
           echo "srcpkg_artifact=prepared-release-source" >> "$GITHUB_OUTPUT"
-          echo "srcpkg_name=${{ steps.prepare.outputs.srcpkg_name }}" >> "$GITHUB_OUTPUT"
-          echo "release_version=${{ steps.prepare.outputs.release_version }}" >> "$GITHUB_OUTPUT"
+          echo "srcpkg_name=${STEPS_PREPARE_OUTPUTS_SRCPKG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "release_version=${STEPS_PREPARE_OUTPUTS_RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 
   build-and-test:
     name: Build and Test

--- a/.github/workflows/pkg-upstream-pr-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-upstream-pr-build-reusable-workflow.yml
@@ -70,11 +70,15 @@ jobs:
     steps:
 
       - name: Print caller info
+        env:
+          INPUTS_UPSTREAM_REPO: ${{inputs.upstream-repo}}
+          INPUTS_UPSTREAM_REPO_REF: ${{inputs.upstream-repo-ref}}
+          INPUTS_PKG_REPO: ${{inputs.pkg-repo}}
         run: |
-          echo "upstream-repo : ${{inputs.upstream-repo}}"
-          echo "upstream-repo-ref : ${{inputs.upstream-repo-ref}}"
-          echo "pkg-repo : ${{inputs.pkg-repo}}"
-          if [[ -z "${{inputs.pkg-repo}}" ]]; then
+          echo "upstream-repo : ${INPUTS_UPSTREAM_REPO}"
+          echo "upstream-repo-ref : ${INPUTS_UPSTREAM_REPO_REF}"
+          echo "pkg-repo : ${INPUTS_PKG_REPO}"
+          if [[ -z "${INPUTS_PKG_REPO}" ]]; then
             echo "ERROR: inputs.pkg-repo is empty. Make sure that the caller workflow's repo has the repo variable PKG_REPO_GITHUB_NAME populated with the correct value. This variable should be in the format of owner/repo-name, for example: qualcomm-linux/pkg-repo"
             exit 1
           fi
@@ -123,11 +127,14 @@ jobs:
           git fetch upstream-source "+refs/tags/*:refs/tags/*"
 
       - name: Merge Upstream PR Changes to Packaging Repo on top of debian/qcom-next
+        env:
+          VARS_DEB_PKG_BOT_CI_NAME: ${{vars.DEB_PKG_BOT_CI_NAME}}
+          VARS_DEB_PKG_BOT_CI_EMAIL: ${{vars.DEB_PKG_BOT_CI_EMAIL}}
         run: |
           cd ./package-repo
 
-          git config user.name "${{vars.DEB_PKG_BOT_CI_NAME}}"
-          git config user.email "${{vars.DEB_PKG_BOT_CI_EMAIL}}"
+          git config user.name "${VARS_DEB_PKG_BOT_CI_NAME}"
+          git config user.email "${VARS_DEB_PKG_BOT_CI_EMAIL}"
 
           git checkout upstream/latest
           git checkout debian/qcom-next
@@ -173,17 +180,21 @@ jobs:
             upstream/latest
 
       - name: Promote Changelog
+        env:
+          VARS_DEB_PKG_BOT_CI_NAME: ${{vars.DEB_PKG_BOT_CI_NAME}}
+          VARS_DEB_PKG_BOT_CI_EMAIL: ${{vars.DEB_PKG_BOT_CI_EMAIL}}
+          INPUTS_SUITE: ${{inputs.suite}}
         run: |
           cd ./package-repo
 
-          export DEBFULLNAME="${{vars.DEB_PKG_BOT_CI_NAME}}"
-          export DEBEMAIL="${{vars.DEB_PKG_BOT_CI_EMAIL}}"
+          export DEBFULLNAME="${VARS_DEB_PKG_BOT_CI_NAME}"
+          export DEBEMAIL="${VARS_DEB_PKG_BOT_CI_EMAIL}"
 
           # use ignore branch because we are not on default debian branch
           # use -b to ignore new version is less than current version. This happens because of the ~pr#
           gbp dch \
             --ignore-branch \
-            --distribution=${{inputs.suite}} \
+            --distribution=${INPUTS_SUITE} \
             --new-version=${{env.upstream_version}}~pr${{inputs.pr-number}}-${{env.distro_revision}} \
             --dch-opt="-b"
 


### PR DESCRIPTION
## Summary
- remediate repo-wide high-severity template-injection findings by routing template expressions through `env` variables
- remove github-env high findings in `push_to_repo` by using step outputs instead of writing to `GITHUB_ENV`
- add a targeted `zizmor: ignore[unpinned-images]` for the dynamic suite-based pkg-builder container image

## Validation
- ran `zizmor --config /tmp/zizmor-policy.yml --min-severity high --persona regular .`
- result: no high-severity findings

