### PR TITLE
flash: support both qcom-ptool script layouts in gen-flash-dirs.sh

### DIFF
--- a/flash/gen-flash-dirs.sh
+++ b/flash/gen-flash-dirs.sh
@@ -92,6 +92,22 @@ mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR=$(realpath "$OUTPUT_DIR")
 [[ -n "$CONTENTS_XML_IN" ]] && CONTENTS_XML_IN=$(realpath "$CONTENTS_XML_IN")
 
+# qcom-ptool moved its Python scripts (gen_partition.py, ptool.py,
+# gen_contents.py) from the repo root into a qcom_ptool/ package directory,
+# and ptool.py now imports its sibling utils module as "qcom_ptool.utils".
+# Support both layouts: platforms/ stays at the repo root either way, but
+# the scripts directory and PYTHONPATH differ.
+if [[ -f "${PTOOL_DIR}/qcom_ptool/ptool.py" ]]; then
+    PTOOL_SCRIPTS_DIR="${PTOOL_DIR}/qcom_ptool"
+    PTOOL_PYTHONPATH="${PTOOL_DIR}"
+elif [[ -f "${PTOOL_DIR}/ptool.py" ]]; then
+    PTOOL_SCRIPTS_DIR="${PTOOL_DIR}"
+    PTOOL_PYTHONPATH=""
+else
+    echo "[ERROR] ptool.py not found under ${PTOOL_DIR} or ${PTOOL_DIR}/qcom_ptool"
+    exit 1
+fi
+
 command -v python3   &>/dev/null || { echo "[ERROR] python3 is required"; exit 1; }
 command -v jq        &>/dev/null || { echo "[ERROR] jq is required";     exit 1; }
 command -v xmlstarlet &>/dev/null || { echo "[ERROR] xmlstarlet is required"; exit 1; }
@@ -223,10 +239,10 @@ for i in $(seq 0 $((BOARD_COUNT - 1))); do
                 PART_MAP="${PART_MAP},cdt=cdt.bin"
             fi
 
-            python3 "${PTOOL_DIR}/gen_partition.py" \
+            python3 "${PTOOL_SCRIPTS_DIR}/gen_partition.py" \
                 -i "$CONF" -o "partition_${storage}.xml" \
                 ${PART_MAP:+-m "$PART_MAP"}
-            python3 "${PTOOL_DIR}/ptool.py" \
+            PYTHONPATH="${PTOOL_PYTHONPATH}" python3 "${PTOOL_SCRIPTS_DIR}/ptool.py" \
                 -x "partition_${storage}.xml" \
                 -t "./partition_${storage}"
             cleanup_flash_dir "./partition_${storage}"
@@ -372,7 +388,7 @@ for k in $(seq 0 $((BOARD_COUNT - 1))); do
         CX_PARTITION_XML="${CX_PTOOL_WORK}/partition_spinor.xml"
         if [[ -n "$CX_TEMPLATE" && -f "$CX_PARTITION_XML" ]]; then
             CX_OUT="${CX_TARGET_DIR}/spinor/contents.xml"
-            python3 "${PTOOL_DIR}/gen_contents.py" \
+            python3 "${PTOOL_SCRIPTS_DIR}/gen_contents.py" \
                 -t "$CX_TEMPLATE" \
                 -p "$CX_PARTITION_XML" \
                 -o "$CX_OUT"
@@ -406,7 +422,7 @@ for k in $(seq 0 $((BOARD_COUNT - 1))); do
             CX_PARTITION_XML="${CX_PTOOL_WORK}/partition_${s}.xml"
             if [[ -n "$CX_TEMPLATE" && -f "$CX_PARTITION_XML" ]]; then
                 CX_OUT="${CX_TARGET_DIR}/${s}/contents.xml"
-                python3 "${PTOOL_DIR}/gen_contents.py" \
+                python3 "${PTOOL_SCRIPTS_DIR}/gen_contents.py" \
                     -t "$CX_TEMPLATE" \
                     -p "$CX_PARTITION_XML" \
                     -o "$CX_OUT"


### PR DESCRIPTION
## Problem

qcom-ptool moved `gen_partition.py`, `ptool.py`, and `gen_contents.py` from the repo root into a `qcom_ptool/` package directory (upstream commit f0f1259), and `ptool.py` now imports its sibling utils module as `qcom_ptool.utils`.

Every qcom-ptool commit that adds `shikra-evk` support lands after this restructure. As a result, pinning `gen-flash-dirs.sh`'s `--ptool-dir` to any commit with shikra-evk support fails with:

```
python3: can't open file '.../boot_bins/qcom-ptool/gen_partition.py': No such file or directory
```

This was reported against `qcom-distro-images`' local developer build guide, which pins an older qcom-ptool commit specifically to avoid this breakage, at the cost of missing shikra-evk support.

## Fix

Detect which layout the pinned qcom-ptool checkout uses and resolve the scripts directory (and `PYTHONPATH`, needed by the new `ptool.py` intra-package import) accordingly. `platforms/` stays at the repo root in both layouts, so no other path resolution changes are needed.

I considered switching to the new `pip install .` + `qcom-ptool` unified CLI entry point (which is the direction upstream has moved, and what their own Makefile now uses), but the `pkg-builder` container has neither `pip` nor `setuptools` installed, so that would add a new dependency to the build environment. The layout-detection approach avoids that entirely and keeps `gen-flash-dirs.sh` self-contained.

## Validation

Ran `gen-flash-dirs.sh` locally against all four `resolute/iot` boards (`iq-x7181-evk`, `qcs6490-rb3gen2-vision-kit`, `iq-9075-evk`, `iq-8275-evk`) with:

- The previously pinned qcom-ptool commit (old, repo-root layout): completes successfully, no regression.
- Current qcom-ptool tip (new, `qcom_ptool/` layout, includes shikra-evk): completes successfully. Directory structure matches the old-layout run exactly (only additional GPT backup files present, from unrelated upstream ptool changes, not from this fix).
- `shikra-evk`'s own partition config directly: `gen_partition.py` and `ptool.py` both run successfully and produce partition XML/GPT output for shikra-evk, confirming the exact failure mode reported is resolved.

## Files changed

| File | Change |
|------|--------|
| `flash/gen-flash-dirs.sh` | Detect qcom-ptool script layout (repo root vs `qcom_ptool/`) and resolve script paths and `PYTHONPATH` accordingly |