### PR TITLE
rootfs/scripts: add qcom user to audio/video groups

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -630,6 +630,8 @@ $CMD_KERNEL_INSTALL
 adduser --disabled-password --gecos '' qcom
 echo 'qcom:qcom' | chpasswd
 usermod -aG sudo qcom
+usermod -aG audio qcom
+usermod -aG video qcom
 
 echo '[CHROOT] Installing manifest packages (if any)...'
 /install_manifest_pkgs.sh || true


### PR DESCRIPTION
As per requirement from audio/video teams, some test cases need user "qcom" to be added in group audio and video. Issues are specific to internal build as qcom user used.

Checked on canonical build, the default user "ubuntu" was added in vidoe/audio groups. so keep align to add "qcom" user to these groups as well.

Canonical image:
ubuntu@ubuntu:/etc/cloud$ groups ubuntu
ubuntu : ubuntu adm cdrom sudo audio dip video plugdev render lxd

Issue:
https://github.com/qualcomm-linux/qcom-distro-images/issues/90