### PR TITLE
build-rootfs: install package from manifest after linux header

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -631,9 +631,6 @@ adduser --disabled-password --gecos '' qcom
 echo 'qcom:qcom' | chpasswd
 usermod -aG sudo qcom
 
-echo '[CHROOT] Installing manifest packages (if any)...'
-/install_manifest_pkgs.sh || true
-
 echo '[CHROOT] Installing local .deb packages via local APT repository (if any)...'
 if ls /opt/local-debs/*.deb >/dev/null 2>&1; then
     echo '[CHROOT] Setting up local .deb APT repository...'
@@ -650,6 +647,9 @@ if ls /opt/local-debs/*.deb >/dev/null 2>&1; then
 else
     echo '[CHROOT] No local .deb packages found; skipping.'
 fi
+
+echo '[CHROOT] Installing manifest packages (if any)...'
+/install_manifest_pkgs.sh || true
 
 # ==============================================================================
 # Run update-grub after ALL installs (firmware, kernel via dpkg or apt, manifest,


### PR DESCRIPTION
As part of requirement to integrate adreno packages on server distro, ensure linux header package installed before installation of kgsl dkms package.