### PR TITLE
flash/gen-flash-dirs: update the storage folder name in bootbins

### DIFF
--- a/flash/gen-flash-dirs.sh
+++ b/flash/gen-flash-dirs.sh
@@ -290,7 +290,10 @@ for i in $(seq 0 $((BOARD_COUNT - 1))); do
         #    archive, boot bins are there; otherwise they are flat at archive root.
         #    Copy everything (including any pre-existing partition files from the
         #    archive) — ptool will overwrite them in step 2.
-        BOOT_BIN_SRC="${BOARD_BOOT_DIR}/partition_${storage}"
+        if [[ -d "${BOARD_BOOT_DIR}/partition_${storage}" ]]; then
+            BOOT_BIN_SRC="${BOARD_BOOT_DIR}/partition_${storage}"
+        else
+            BOOT_BIN_SRC="${BOARD_BOOT_DIR}/${storage}"
         if [[ ! -d "$BOOT_BIN_SRC" ]]; then
             BOOT_BIN_SRC="${BOARD_BOOT_DIR}"
         fi


### PR DESCRIPTION
In bootbins release tag 00015, the subfolder in HAMOA_bootbinaries is ufs/nvme/spinor, instead of partition_ufs/partition_nvme/partition_spinor. 
https://softwarecenter.qualcomm.com/nexus/generic/product/chip/tech-package/Hamoa_bootbinaries.1.0/hamoa_bootbinaries.1.0-test-device-public/00015/HAMOA_bootbinaries/
