### PR TITLE
rootfs: add udev rule to autostart remoteproc

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -653,6 +653,12 @@ fi
 echo '[CHROOT] Installing manifest packages (if any)...'
 /install_manifest_pkgs.sh || true
 
+echo '[CHROOT] Installing udev rule to autostart remoteproc DSPs on attach...'
+cat <<'REMOTEPROC_RULES' > /etc/udev/rules.d/99-remoteproc-autostart.rules
+# Match on the stable sysfs 'name'; the remoteprocN index varies by probe order.
+ACTION==\"add\", SUBSYSTEM==\"remoteproc\", ATTR{name}==\"adsp|cdsp|cdsp1|gpdsp0|gpdsp1\", ATTR{state}==\"offline\", ATTR{state}=\"start\"
+REMOTEPROC_RULES
+
 # ==============================================================================
 # Run update-grub after ALL installs (firmware, kernel via dpkg or apt, manifest,
 # local-debs). This ensures GRUB sees whichever kernel was installed last,


### PR DESCRIPTION
Adds a udev rule to build-rootfs.sh that autostarts the adsp and cdsp remote processors on attach, so they come up automatically without a manual `echo start > /sys/class/remoteproc/remoteprocN/state`.

  The rule matches on the stable sysfs `name` attribute rather than the `remoteprocN` index, since the number is assigned in probe order and is not guaranteed to map to the same processor across boards or kernel versions:

  ACTION=="add", SUBSYSTEM=="remoteproc", ATTR{name}=="adsp", ATTR{state}="start"
  ACTION=="add", SUBSYSTEM=="remoteproc", ATTR{name}=="cdsp", ATTR{state}="start"

  The rule is injected into the existing chroot provisioning block in build-rootfs.sh, after manifest package installation and before update-grub.

  Ref: https://github.com/qualcomm-linux/qcom-distro-images/issues/91
