### PR TITLE
pkg-build: upload proposed debs to S3 for Ubuntu PR builds

### DIFF
--- a/.github/workflows/pkg-build-reusable-workflow.yml
+++ b/.github/workflows/pkg-build-reusable-workflow.yml
@@ -582,3 +582,53 @@ jobs:
             echo "- Skipped: Validate installability from Debusine CI workspace"
             echo "- Skipped: Validate installability from Docker build artifacts"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  Upload_to_S3:
+    name: Upload to S3
+    if: >-
+      ${{
+        always() &&
+        github.event_name == 'pull_request' &&
+        needs.resolve.outputs.family == 'ubuntu' &&
+        needs.docker-build.result == 'success' &&
+        needs.test.result == 'success'
+      }}
+    needs:
+      - resolve
+      - docker-build
+      - test
+    runs-on: lecore-prd-u2404-arm64-xlrg-od-ephem
+    defaults:
+      run:
+        shell: bash
+    steps:
+
+      - name: Download Docker build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: docker-build-area
+          path: .
+
+      - name: Extract Docker build artifacts
+        run: |
+          set -euxo pipefail
+          mkdir -p build-area
+          tar -C build-area -xzf docker-build-area.tgz
+
+      - name: Stage debs for S3 proposed upload
+        run: |
+          set -euxo pipefail
+          mkdir -p s3-proposed
+          mapfile -t debs < <(find build-area -maxdepth 1 -name "*.deb" -printf '%f\n' | sort)
+          if [ "${#debs[@]}" -eq 0 ]; then
+            echo "No .deb files found in build-area; skipping debs.tar.gz creation"
+          else
+            tar -czf s3-proposed/debs.tar.gz -C build-area "${debs[@]}"
+          fi
+
+      - name: Upload proposed debs to S3
+        uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+        with:
+          s3_bucket: qli-prd-lecore-gh-artifacts
+          path: s3-proposed
+          destination: qualcomm-linux/pkg/proposed/${{ github.run_id }}-${{ github.run_attempt }}/


### PR DESCRIPTION
## Summary
- Adds an `Upload_to_S3` job to `pkg-build-reusable-workflow.yml` that, for Ubuntu-family pull request builds, downloads the `docker-build-area` artifact, stages the built `.deb` files into a tarball, and uploads them to the `qli-prd-lecore-gh-artifacts` S3 bucket under `qualcomm-linux/pkg/proposed/${{ github.run_id }}-${{ github.run_attempt }}/`.
- Runs only when `github.event_name == 'pull_request'`, `family == 'ubuntu'`, and both `docker-build` and `test` succeeded.
