### PR TITLE
build-rootfs: grant qcom user non-root access to DMA heap

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -633,6 +633,15 @@ usermod -aG sudo qcom
 usermod -aG audio qcom
 usermod -aG video qcom
 
+# create dmaheap group and add qcom user in this group
+groupadd dmaheap
+usermod -aG dmaheap qcom
+
+echo '[CHROOT] Installing udev rule for DMA heap group access...'
+cat <<'EOF' > /etc/udev/rules.d/99-dma-heap.rules
+SUBSYSTEM==\"dma_heap\", KERNEL==\"system\", GROUP=\"dmaheap\", MODE=\"0660\"
+EOF
+
 echo '[CHROOT] Installing local .deb packages via local APT repository (if any)...'
 if ls /opt/local-debs/*.deb >/dev/null 2>&1; then
     echo '[CHROOT] Setting up local .deb APT repository...'


### PR DESCRIPTION
Add a dedicated 'dmaheap' group, assign user 'qcom' to it, and install a persistent udev rule (99-dma-heap.rules) that sets GROUP=dmaheap and MODE=0660 on /dev/dma_heap/system. This allows the qcom user to access /dev/dma_heap/system without root privileges.

Issue:
https://github.com/qualcomm-linux/qcom-distro-images/issues/116