### PR TITLE
build-rootfs: add initramfs hook to omit qcom_q6v5_pas driver

### DIFF
--- a/rootfs/scripts/build-rootfs.sh
+++ b/rootfs/scripts/build-rootfs.sh
@@ -431,6 +431,37 @@ if [[ -n "$FIRMWARE_DEB" ]]; then
     cp "$FIRMWARE_DEB" "$ROOTFS_DIR/"
 fi
 
+# ------------------------------------------------------------------
+# Inject initramfs-tools hook to omit qcom_q6v5_pas from the initramfs.
+# Must be in place BEFORE the kernel .deb is installed in chroot, since
+# that dpkg step triggers update-initramfs. Also persists into the final
+# image so future kernel updates keep omitting the driver.
+# ------------------------------------------------------------------
+echo "[INFO] Installing initramfs-tools hook to omit qcom_q6v5_pas..."
+mkdir -p "$ROOTFS_DIR/etc/initramfs-tools/hooks"
+cat <<'HOOK_EOF' > "$ROOTFS_DIR/etc/initramfs-tools/hooks/omit"
+#!/bin/sh
+PREREQ=""
+prereqs()
+{
+    echo "$PREREQ"
+}
+
+case "$1" in
+    prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+OMIT_DRIVERS="qcom_q6v5_pas.ko*"
+
+for i in ${OMIT_DRIVERS}; do
+    find "${DESTDIR}" -name "${i}" -delete
+done
+HOOK_EOF
+chmod +x "$ROOTFS_DIR/etc/initramfs-tools/hooks/omit"
+
 echo "[INFO] Replacing /etc/resolv.conf with host copy for apt inside chroot..."
 rm -f "$ROOTFS_DIR/etc/resolv.conf"
 cp -L /etc/resolv.conf "$ROOTFS_DIR/etc/resolv.conf"


### PR DESCRIPTION
Inject an initramfs-tools hook at /etc/initramfs-tools/hooks/omit into the rootfs before the kernel .deb is installed in chroot. Since that dpkg step triggers update-initramfs, the hook must exist beforehand so the baked initramfs excludes
qcom_q6v5_pas.ko*. The hook also persists into the final image so future kernel upgrades keep omitting the driver.