### PR TITLE
ci: post check run for release S3 upload

### DIFF
--- a/.github/pkg-workflows/qli-ci/pkg-release.yml
+++ b/.github/pkg-workflows/qli-ci/pkg-release.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   packages: read
+  checks: write
 
 jobs:
   Release:

--- a/.github/workflows/pkg-release-reusable-workflow.yml
+++ b/.github/workflows/pkg-release-reusable-workflow.yml
@@ -64,6 +64,7 @@ jobs:
       srcpkg_name: ${{ steps.select.outputs.srcpkg_name }}
       release_version: ${{ steps.select.outputs.release_version }}
       release_tag_name: ${{ steps.select.outputs.release_tag_name }}
+      source_commit_sha: ${{ steps.source-sha.outputs.sha }}
     defaults:
       run:
         shell: bash
@@ -160,6 +161,13 @@ jobs:
           ref: ${{ steps.resolve.outputs.normalized_ref }}
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Resolve source commit SHA
+        id: source-sha
+        working-directory: ./package-repo
+        run: |
+          set -euxo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release source state
         id: prepare
@@ -779,8 +787,12 @@ jobs:
     name: Upload Debs to S3 (Ubuntu)
     if: ${{ needs.build-and-test.outputs.family == 'ubuntu' }}
     needs:
+      - prepare-release-source
       - build-and-test
     runs-on: lecore-prd-u2404-arm64-xlrg-od-ephem
+    permissions:
+      contents: read
+      checks: write
     defaults:
       run:
         shell: bash
@@ -811,8 +823,62 @@ jobs:
           fi
 
       - name: Upload proposed debs and provenance to S3
+        id: upload
         uses: qualcomm-linux/upload-private-artifact-action@aws-v4
         with:
           s3_bucket: qli-prd-lecore-gh-artifacts
           path: s3-proposed
           destination: qualcomm-linux/pkg/proposed/${{ github.run_id }}-${{ github.run_attempt }}/
+
+      - name: Install jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends jq
+
+      - name: Post release check run
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ needs.prepare-release-source.outputs.source_commit_sha }}
+          UPLOAD_OUTCOME: ${{ steps.upload.outcome }}
+        run: |
+          set -euo pipefail
+          conclusion="success"
+          if [[ "${UPLOAD_OUTCOME}" != "success" ]]; then
+            conclusion="failure"
+          fi
+          s3_location="qualcomm-linux/pkg/proposed/${{ github.run_id }}-${{ github.run_attempt }}"
+          payload=$(jq -n \
+            --arg head_sha "${COMMIT_SHA}" \
+            --arg conclusion "${conclusion}" \
+            --arg details_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg s3_location "${s3_location}" \
+            '{
+              name: "pkg-release-check-run",
+              head_sha: $head_sha,
+              status: "completed",
+              conclusion: $conclusion,
+              details_url: $details_url,
+              output: {
+                title: "pkg-release-check-run",
+                summary: ("Release check run " + $conclusion),
+                text: $s3_location
+              }
+            }')
+          response=$(curl -sS -w '\n%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/check-runs" \
+            -d "${payload}")
+          http_code=$(tail -n1 <<< "$response")
+          body=$(sed '$d' <<< "$response")
+          if [[ "$http_code" != "201" ]]; then
+            echo "::error::Failed to create check run (HTTP ${http_code}): ${body}"
+            exit 1
+          fi
+          check_run_url=$(echo "$body" | jq -r '.html_url')
+          echo "### Release check run: ${conclusion}" >> "$GITHUB_STEP_SUMMARY"
+          echo "[${check_run_url}](${check_run_url})" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Add a check run (`pkg-release-check-run`) to the `upload-debs-to-s3` job, posted as completed with the upload outcome and the S3 destination path, so Coral can subscribe to the `check_run` event instead of the Status API.
- Write the check run's `html_url` to `GITHUB_STEP_SUMMARY`.
- Grant `checks: write` in the `pkg-release.yml` stub under `.github/pkg-workflows/qli-ci/`, since that permission must be declared by the caller workflow for the reusable workflow's check-run step to run. This stub is synced to all `pkg-*` repos.

